### PR TITLE
[feature] Test Shell의 read 출력 양식 변경

### DIFF
--- a/TestShell/shell_read_test.cpp
+++ b/TestShell/shell_read_test.cpp
@@ -16,7 +16,7 @@ public:
 		std::string filePath = "ssd_output.txt";
 		std::ofstream outfile(filePath);
 		outfile << EXPECT_AA << std::endl;
-		outfile.close();		
+		outfile.close();
 	}
 };
 

--- a/TestShell/shell_read_test.cpp
+++ b/TestShell/shell_read_test.cpp
@@ -6,7 +6,11 @@ class TestShellRead : public Test {
 public:
 	TestShell shell;
 	MockSSD ssd;
-	string EXPECT_AA = "0xAAAAAAAA";
+
+	const string HEADER = "[Read] LBA ";
+	const string MIDFIX = " : ";
+	const string FOOTER = "\n";
+	const string EXPECT_AA = "0xAAAAAAAA";
 
 	void ssdReadFileSetUp() {
 		std::string filePath = "ssd_output.txt";
@@ -31,8 +35,8 @@ TEST_F(TestShellRead, ReadPass) {
 	shell.read(0);
 	std::cout.rdbuf(oldCoutStreamBuf); //º¹¿ø
 
-
-	EXPECT_EQ(EXPECT_AA, oss.str());
+	string expect = HEADER + "00" + MIDFIX + EXPECT_AA + FOOTER;
+	EXPECT_EQ(expect, oss.str());
 }
 
 TEST_F(TestShellRead, FullReadPass) {
@@ -52,7 +56,14 @@ TEST_F(TestShellRead, FullReadPass) {
 
 	string expect = "";
 	for (int i = 0; i < 100; i++) {
+		std::ostringstream oss;
+		oss << std::setw(2) << std::setfill('0') << i;
+
+		expect += HEADER;
+		expect += oss.str();
+		expect += MIDFIX;
 		expect += EXPECT_AA;
+		expect += FOOTER;
 	}
 
 	EXPECT_EQ(expect, oss.str());

--- a/TestShell/shell_read_test.cpp
+++ b/TestShell/shell_read_test.cpp
@@ -16,7 +16,7 @@ public:
 		std::string filePath = "ssd_output.txt";
 		std::ofstream outfile(filePath);
 		outfile << EXPECT_AA << std::endl;
-		outfile.close();
+		outfile.close();		
 	}
 };
 
@@ -24,7 +24,8 @@ TEST_F(TestShellRead, ReadPass) {
 	ssdReadFileSetUp();
 	
 	EXPECT_CALL(ssd, read(0))
-		.Times(1);
+		.Times(1)
+		.WillRepeatedly(Return(EXPECT_AA));
 
 	shell.setSSD(&ssd);
 
@@ -43,7 +44,8 @@ TEST_F(TestShellRead, FullReadPass) {
 	ssdReadFileSetUp();
 
 	EXPECT_CALL(ssd, read)
-		.Times(100);
+		.Times(100)
+		.WillRepeatedly(Return(EXPECT_AA));
 
 	shell.setSSD(&ssd);
 

--- a/TestShell/shell_read_test.cpp
+++ b/TestShell/shell_read_test.cpp
@@ -34,7 +34,7 @@ TEST_F(TestShellRead, ReadPass) {
 	std::cout.rdbuf(oss.rdbuf());
 
 	shell.read(0);
-	std::cout.rdbuf(oldCoutStreamBuf); //복원
+	std::cout.rdbuf(oldCoutStreamBuf);
 
 	string expect = HEADER + "00" + MIDFIX + EXPECT_AA + FOOTER;
 	EXPECT_EQ(expect, oss.str());
@@ -54,7 +54,7 @@ TEST_F(TestShellRead, FullReadPass) {
 	std::cout.rdbuf(oss.rdbuf());
 
 	shell.fullRead();
-	std::cout.rdbuf(oldCoutStreamBuf); //복원
+	std::cout.rdbuf(oldCoutStreamBuf);
 
 	string expect = "";
 	for (int i = 0; i < 100; i++) {

--- a/TestShell/ssd_interface.h
+++ b/TestShell/ssd_interface.h
@@ -17,3 +17,19 @@ public:
 	MOCK_METHOD(string, read, (int lba), (override));
 };
 
+class SSDDriver : public SSDInterface {
+public:
+	string read(int lba) override {
+		//string command = ".\program.exe ssd R " + lba;
+		//system(command.c_str());
+
+		string content;
+		std::ifstream file(SSD_READ_RESULT);
+		std::getline(file, content);
+		file.close();
+
+		return content;
+	}
+private:
+	const string SSD_READ_RESULT = "ssd_output.txt";
+};

--- a/TestShell/test_shell.cpp
+++ b/TestShell/test_shell.cpp
@@ -3,17 +3,12 @@
 using std::cout;
 
 void TestShell::read(int lba) {
-	ssd->read(lba);
-
-	std::ifstream file(SSD_READ_RESULT);
-	std::string content;
-	std::getline(file, content);
+	std::string content = ssd->read(lba);
 
 	std::ostringstream oss;
 	oss << std::setw(2) << std::setfill('0') << lba;
 
 	cout << READ_HEADER << oss.str() << READ_MIDFIX << content << READ_FOOTER;
-	file.close();
 }
 
 void TestShell::fullRead()

--- a/TestShell/test_shell.cpp
+++ b/TestShell/test_shell.cpp
@@ -7,10 +7,12 @@ void TestShell::read(int lba) {
 
 	std::ifstream file(SSD_READ_RESULT);
 	std::string content;
-
 	std::getline(file, content);
 
-	cout << content;
+	std::ostringstream oss;
+	oss << std::setw(2) << std::setfill('0') << lba;
+
+	cout << READ_HEADER << oss.str() << READ_MIDFIX << content << READ_FOOTER;
 	file.close();
 }
 

--- a/TestShell/test_shell.h
+++ b/TestShell/test_shell.h
@@ -14,4 +14,7 @@ private:
 	SSDInterface* ssd;
 	const string SSD_READ_RESULT = "ssd_output.txt";
 	const int MAX_LBA = 100;
+	const string READ_HEADER = "[Read] LBA ";
+	const string READ_MIDFIX = " : ";
+	const string READ_FOOTER = "\n";
 };

--- a/TestShell/test_shell.h
+++ b/TestShell/test_shell.h
@@ -12,7 +12,6 @@ public:
 	void write(int lba, std::string value);
 private:
 	SSDInterface* ssd;
-	const string SSD_NAND = "ssd_nand.txt";
 	const string SSD_READ_RESULT = "ssd_output.txt";
 	const int MAX_LBA = 100;
 };

--- a/TestShell/test_shell.h
+++ b/TestShell/test_shell.h
@@ -13,7 +13,6 @@ public:
 	void fullWrite(std::string value);
 private:
 	SSDInterface* ssd;
-	const string SSD_READ_RESULT = "ssd_output.txt";
 	const int MAX_LBA = 100;
 	const string READ_HEADER = "[Read] LBA ";
 	const string READ_MIDFIX = " : ";


### PR DESCRIPTION
## 📌 PR 제목
- [feature] Test Shell의 read 출력 양식 및 로직 변경, SSDDriver 대략적인 로직 추가
 
## 📄 변경 사항
- 이전 PR의 리뷰 코멘트로 받은 read 출력 양식 부분 변경했습니다.
- Test Shell의 Read에 대한 Unit Test 및 메서드 로직을 처음에 구현한 대로 원복했습니다.
- SSDInterface를 상속받는 SSDDriver를 추가했습니다. 

## 🔍 상세 설명
- pdf에 있는 양식대로 수정했습니다.
- Test Script 구현하신 걸 보면 제가 처음에 와꾸 짜둔 대로 SSDInterface의 read가 string을 반환받는다는 가정 하에 구현이 되어있다보니, 중간에 바뀐 로직보다는 처음에 구현한 대로 Test Shell에서는 return 값을 출력만 하고, Driver에서 파일 오픈 및 string 반환을 하는 것이 덜 손이 갈듯 해서 로직을 원복했습니다.
- SSDInterface를 상속받는 SSDDriver를 및 read에 대한 내용을 대략적으로 추가했습니다. (실제 test는 SSD.exe가 구동이 되어야 확인 가능할 듯 합니다)

## ✅ 체크리스트
- [x] 코드 스타일을 따랐는가?
- [x] 테스트를 작성했는가?
- [x] master branch 리베이스 후 빌드 확인 하였는가?