### PR TITLE
Feature/ssd driver read

### DIFF
--- a/TestShell/main.cpp
+++ b/TestShell/main.cpp
@@ -12,8 +12,17 @@ int main() {
 #else
 
 int main() {
+<<<<<<< HEAD
 	TestShell ts;
 	ts.runShell();
+=======
+	TestShell shell;
+	SSDDriver ssd;
+
+	shell.setSSD(&ssd);
+	shell.runShell();
+
+>>>>>>> b3e8193 ([feature] Add Assertion with exe)
 	return 0;
 }
 

--- a/TestShell/main.cpp
+++ b/TestShell/main.cpp
@@ -12,17 +12,14 @@ int main() {
 #else
 
 int main() {
-<<<<<<< HEAD
+
 	TestShell ts;
-	ts.runShell();
-=======
-	TestShell shell;
+
 	SSDDriver ssd;
+	ts.setSSD(&ssd);
 
-	shell.setSSD(&ssd);
-	shell.runShell();
+	ts.runShell();
 
->>>>>>> b3e8193 ([feature] Add Assertion with exe)
 	return 0;
 }
 

--- a/TestShell/shell_read_test.cpp
+++ b/TestShell/shell_read_test.cpp
@@ -22,7 +22,7 @@ public:
 
 TEST_F(TestShellRead, ReadPass) {
 	ssdReadFileSetUp();
-	
+
 	EXPECT_CALL(ssd, read(0))
 		.Times(1)
 		.WillRepeatedly(Return(EXPECT_AA));
@@ -69,4 +69,24 @@ TEST_F(TestShellRead, FullReadPass) {
 	}
 
 	EXPECT_EQ(expect, oss.str());
+}
+
+TEST(SSDDriverRead, ReadPass) {
+	MockSSDDriver mockSSD;
+
+	EXPECT_CALL(mockSSD, runExe)
+		.Times(1)
+		.WillRepeatedly(Return(true));
+
+	EXPECT_TRUE(mockSSD.read(0));
+}
+
+TEST(SSDDriverRead, ReadPass) {
+	MockSSDDriver mockSSD;
+
+	EXPECT_CALL(mockSSD, runExe)
+		.Times(1)
+		.WillRepeatedly(Return(false));
+
+	EXPECT_THROW(mockSSD.read(0), std::runtime_error);
 }

--- a/TestShell/shell_read_test.cpp
+++ b/TestShell/shell_read_test.cpp
@@ -78,15 +78,21 @@ TEST(SSDDriverRead, ReadPass) {
 		.Times(1)
 		.WillRepeatedly(Return(true));
 
-	EXPECT_TRUE(mockSSD.read(0));
+	EXPECT_EQ("0xAAAAAAAA", mockSSD.read(0));
 }
 
-TEST(SSDDriverRead, ReadPass) {
+TEST(SSDDriverRead, ReadFail) {
 	MockSSDDriver mockSSD;
 
 	EXPECT_CALL(mockSSD, runExe)
 		.Times(1)
 		.WillRepeatedly(Return(false));
 
-	EXPECT_THROW(mockSSD.read(0), std::runtime_error);
+	try {
+		mockSSD.read(0);
+		FAIL();
+	}
+	catch (std::runtime_error e) {
+		EXPECT_EQ(std::string(e.what()), "There is no SSD.exe");
+	}
 }

--- a/TestShell/ssd_interface.h
+++ b/TestShell/ssd_interface.h
@@ -19,9 +19,18 @@ public:
 
 class SSDDriver : public SSDInterface {
 public:
+	virtual bool runExe(const string& command) {
+		int ret = system(command.c_str());
+
+		if (ret == 0) return true;
+		return false;
+	}
+	void write(int lba, string value) override {
+
+	}
 	string read(int lba) override {
-		//string command = ".\program.exe ssd R " + lba;
-		//system(command.c_str());
+		string command = ".\program.exe ssd R " + lba;
+		if (runExe(command) == false) { throw std::runtime_error("There is no SSD.exe"); }
 
 		string content;
 		std::ifstream file(SSD_READ_RESULT);
@@ -32,4 +41,9 @@ public:
 	}
 private:
 	const string SSD_READ_RESULT = "ssd_output.txt";
+};
+
+class MockSSDDriver : public SSDDriver {
+public:
+	MOCK_METHOD(bool, runExe, (const string& command), (override));
 };

--- a/TestShell/ssd_interface.h
+++ b/TestShell/ssd_interface.h
@@ -29,8 +29,8 @@ public:
 
 	}
 	string read(int lba) override {
-		string command = ".\SSD.exe ssd R " + lba;
-		if (runExe(command) == false) { throw std::runtime_error("There is no SSD.exe"); }
+		string command = "\"SSD.exe >nul 2>&1\"";
+		if (runExe(command) == false) { throw std::runtime_error("There is no SSD.exe\n"); }
 
 		string content;
 		std::ifstream file(SSD_READ_RESULT);

--- a/TestShell/ssd_interface.h
+++ b/TestShell/ssd_interface.h
@@ -29,7 +29,7 @@ public:
 
 	}
 	string read(int lba) override {
-		string command = ".\program.exe ssd R " + lba;
+		string command = ".\SSD.exe ssd R " + lba;
 		if (runExe(command) == false) { throw std::runtime_error("There is no SSD.exe"); }
 
 		string content;

--- a/TestShell/test_shell.cpp
+++ b/TestShell/test_shell.cpp
@@ -1,12 +1,6 @@
 ﻿#include "test_shell.h"
-<<<<<<< HEAD
 #include "command_parser.h"
 #include <iostream>
-=======
->>>>>>> b3e8193 ([feature] Add Assertion with exe)
-#include <sstream>
-#include <vector>
-#include <string>
 
 using std::cout;
 
@@ -18,7 +12,6 @@ void TestShell::runShell()
         std::cout << "shell > ";
         std::getline(std::cin, inputLine);
 
-<<<<<<< HEAD
         if (inputLine.empty()) continue;
 
         commandParser.setCommand(inputLine);
@@ -70,60 +63,6 @@ void TestShell::runShell()
         }
         else {
             std::cout << "[Error] Unknown command: " << opCommand << std::endl;
-=======
-        // Skip empty input
-
-        if (inputLine.empty()) continue;
-
-        // Tokenize command
-        std::istringstream ss(inputLine);
-        std::string command;
-        ss >> command;
-
-        if (command == "exit") {
-            break;
-        }
-        else if (command == "help") {
-            help();
-        }
-        else if (command == "write") {
-            int lba;
-            std::string value;
-            ss >> lba >> value;
-            std::cout << "Executing write to LBA " << lba << " with value " << value << std::endl;
-            // Call write(lba, value);
-        }
-        else if (command == "read") {
-            int lba;
-            ss >> lba;
-            std::cout << "Executing read from LBA " << lba << std::endl;
-            read(lba);
-        }
-        else if (command == "fullwrite") {
-            std::string value;
-            ss >> value;
-            std::cout << "Executing fullwrite with value " << value << std::endl;
-            // Call fullwrite(value);
-        }
-        else if (command == "fullread") {
-            std::cout << "Executing fullread" << std::endl;
-            fullRead();
-        }
-        else if (command == "1_" || command == "1_FullWriteAndReadCompare") {
-            std::cout << "Running script 1: FullWriteAndReadCompare" << std::endl;
-            // Call TestScript1::Run();
-        }
-        else if (command == "2_" || command == "2_PartialLBAWrite") {
-            std::cout << "Running script 2: PartialLBAWrite" << std::endl;
-            // Call TestScript2::Run();
-        }
-        else if (command == "3_" || command == "3_WriteReadAging") {
-            std::cout << "Running script 3: WriteReadAging" << std::endl;
-            // Call TestScript3::writeReadAging();
-        }
-        else {
-            std::cout << "[Error] Unknown command: " << command << std::endl;
->>>>>>> b3e8193 ([feature] Add Assertion with exe)
         }
     }
 }

--- a/TestShell/test_shell.cpp
+++ b/TestShell/test_shell.cpp
@@ -1,6 +1,9 @@
 ﻿#include "test_shell.h"
+<<<<<<< HEAD
 #include "command_parser.h"
 #include <iostream>
+=======
+>>>>>>> b3e8193 ([feature] Add Assertion with exe)
 #include <sstream>
 #include <vector>
 #include <string>
@@ -15,6 +18,7 @@ void TestShell::runShell()
         std::cout << "shell > ";
         std::getline(std::cin, inputLine);
 
+<<<<<<< HEAD
         if (inputLine.empty()) continue;
 
         commandParser.setCommand(inputLine);
@@ -66,24 +70,93 @@ void TestShell::runShell()
         }
         else {
             std::cout << "[Error] Unknown command: " << opCommand << std::endl;
+=======
+        // Skip empty input
+
+        if (inputLine.empty()) continue;
+
+        // Tokenize command
+        std::istringstream ss(inputLine);
+        std::string command;
+        ss >> command;
+
+        if (command == "exit") {
+            break;
+        }
+        else if (command == "help") {
+            help();
+        }
+        else if (command == "write") {
+            int lba;
+            std::string value;
+            ss >> lba >> value;
+            std::cout << "Executing write to LBA " << lba << " with value " << value << std::endl;
+            // Call write(lba, value);
+        }
+        else if (command == "read") {
+            int lba;
+            ss >> lba;
+            std::cout << "Executing read from LBA " << lba << std::endl;
+            read(lba);
+        }
+        else if (command == "fullwrite") {
+            std::string value;
+            ss >> value;
+            std::cout << "Executing fullwrite with value " << value << std::endl;
+            // Call fullwrite(value);
+        }
+        else if (command == "fullread") {
+            std::cout << "Executing fullread" << std::endl;
+            fullRead();
+        }
+        else if (command == "1_" || command == "1_FullWriteAndReadCompare") {
+            std::cout << "Running script 1: FullWriteAndReadCompare" << std::endl;
+            // Call TestScript1::Run();
+        }
+        else if (command == "2_" || command == "2_PartialLBAWrite") {
+            std::cout << "Running script 2: PartialLBAWrite" << std::endl;
+            // Call TestScript2::Run();
+        }
+        else if (command == "3_" || command == "3_WriteReadAging") {
+            std::cout << "Running script 3: WriteReadAging" << std::endl;
+            // Call TestScript3::writeReadAging();
+        }
+        else {
+            std::cout << "[Error] Unknown command: " << command << std::endl;
+>>>>>>> b3e8193 ([feature] Add Assertion with exe)
         }
     }
 }
 
 void TestShell::read(int lba) {
-	std::string content = ssd->read(lba);
+    std::string content;
+    try {
+        content = ssd->read(lba);
+        std::ostringstream oss;
+        oss << std::setw(2) << std::setfill('0') << lba;
 
-	std::ostringstream oss;
-	oss << std::setw(2) << std::setfill('0') << lba;
-
-	cout << READ_HEADER << oss.str() << READ_MIDFIX << content << READ_FOOTER;
+        cout << READ_HEADER << oss.str() << READ_MIDFIX << content << READ_FOOTER;
+    }
+    catch(std::exception e){
+        cout << string(e.what()) << std::endl;
+    }
 }
 
 void TestShell::fullRead()
 {
-	for (int addr = 0; addr < MAX_LBA; addr++) {
-		read(addr);
-	}
+    std::string content;
+    try {
+	    for (int addr = 0; addr < MAX_LBA; addr++) {       
+            content = ssd->read(addr);
+            std::ostringstream oss;
+            oss << std::setw(2) << std::setfill('0') << addr;
+
+            cout << READ_HEADER << oss.str() << READ_MIDFIX << content << READ_FOOTER;       
+	    }
+    }
+    catch (std::exception e) {
+        cout << string(e.what()) << std::endl;
+    }
 }
 
 void TestShell::write(int lba, std::string value) {

--- a/TestShell/test_shell.h
+++ b/TestShell/test_shell.h
@@ -1,3 +1,6 @@
+#include <sstream>
+#include <vector>
+#include <string>
 #include "ssd_interface.h"
 #include "command_parser.h"
 


### PR DESCRIPTION
## 📌 PR 제목
- [feature] Run exe 가 mock으로 실행되는 unit test 구현 & 더미 SSD.exe가 없으면 Assertion되고 있으면 실행되는 SSDInterface read 구현

## 📄 변경 사항
- Run exe 가 mock으로 실행되는 unit test 구현
- 더미 SSD.exe가 없으면 Assertion되고 있으면 실행되는 SSDInterface read 구현
- SSD.exe에 제대로 된 명령어를 전달하는 건 다음 PR에 진행하겠습니다.

## 🔍 상세 설명
- SSD.exe 완성되기 전 mocking으로 unit test가 필요하다고 생각해서 mock 개체를 두개나 만들었는데.. 슬슬 첫번째 mock은 없애도 될 거 같기는 합니다.
- TestShell 폴더에 SSD.exe 파일이 없으면 에러 메세지 출력 후 다음 shell line 출력, 있으면 exe 파일 실행

## ✅ 체크리스트
- [x] 코드 스타일을 따랐는가?
- [x] 테스트를 작성했는가?
- [x] master branch 리베이스 후 빌드 확인 하였는가?