### PR TITLE
[fix] add execute option

### DIFF
--- a/TestShell/ssd_interface.h
+++ b/TestShell/ssd_interface.h
@@ -40,9 +40,9 @@ public:
 		return true;
 	}
 	void write(int lba, string value) override {
-		string ssdCmd = "\"ssd W " + std::to_string(lba) + " " + value;
-		if (runExe(ssdCmd) == false) {
-			throw SSDExecutionException("Execution failed: " + ssdCmd);
+		string command = "\"ssd W " + std::to_string(lba) + " " + value + " >nul 2>&1\"";
+		if (runExe(command) == false) {
+			throw SSDExecutionException("Execution failed: " + command);
 		}
 	}
 	string read(int lba) override {


### PR DESCRIPTION
## 📌 PR 제목
- [변경 유형] SSD.exe 실행 옵션 추가

## 📄 변경 사항
- Write command 에서도 SSD.exe 실패시 error 출력 안하도록 수정

## 🔍 상세 설명
- Write command 에서도 SSD.exe 실패시 error 출력 안하도록 수정 및 read와 비슷한 형식으로 수정

## ✅ 체크리스트
- [x] 코드 스타일을 따랐는가?
- [x] 테스트를 작성했는가?
- [x] master branch 리베이스 후 빌드 확인 하였는가?