### PR TITLE
[Bug Fix] Print INVALID COMMAND at TestShell when receiving invalid command opcode

### DIFF
--- a/TestShell/TestShell.vcxproj.filters
+++ b/TestShell/TestShell.vcxproj.filters
@@ -54,13 +54,13 @@
     <ClCompile Include="command_parser.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
-    <ClCompile Include="testshell_execute_command_test.cpp">
-      <Filter>소스 파일</Filter>
-    </ClCompile>
     <ClCompile Include="test_script.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
     <ClCompile Include="test_scripts_test.cpp">
+      <Filter>테스트 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="testshell_execute_command_test.cpp">
       <Filter>테스트 파일</Filter>
     </ClCompile>
   </ItemGroup>

--- a/TestShell/command_parser.cpp
+++ b/TestShell/command_parser.cpp
@@ -26,7 +26,31 @@ const std::vector<std::string>& CommandParser::getCommandVector() const
 	return commandVector;
 }
 
-bool CommandParser::isValidCommand() const
+bool CommandParser::isValidOpCommand() const
+{
+	if (commandVector.size() < 1) return false;
+
+	// check operation command
+	string opCommand = commandVector.at(0);
+
+	// check valid commands
+	if (opCommand != CMD_READ
+		&& opCommand != CMD_WRITE
+		&& opCommand != CMD_EXIT
+		&& opCommand != CMD_HELP
+		&& opCommand != CMD_FULLREAD
+		&& opCommand != CMD_FULLWRITE
+		&& opCommand != CMD_SCRIPT1
+		&& opCommand != CMD_SCRIPT1_NAME
+		&& opCommand != CMD_SCRIPT2
+		&& opCommand != CMD_SCRIPT2_NAME
+		&& opCommand != CMD_SCRIPT3
+		&& opCommand != CMD_SCRIPT3_NAME) {
+		return false;
+	}
+}
+
+bool CommandParser::isValidCommandParameter() const
 {
 	try {
 		// check parameter count
@@ -34,25 +58,7 @@ bool CommandParser::isValidCommand() const
 			return false;
 		}
 
-		// check operation command
 		string opCommand = commandVector.at(0);
-
-		// check valid commands
-		if (opCommand != CMD_READ
-			&& opCommand != CMD_WRITE
-			&& opCommand != CMD_EXIT
-			&& opCommand != CMD_HELP
-			&& opCommand != CMD_FULLREAD
-			&& opCommand != CMD_FULLWRITE
-			&& opCommand != CMD_SCRIPT1
-			&& opCommand != CMD_SCRIPT1_NAME
-			&& opCommand != CMD_SCRIPT2
-			&& opCommand != CMD_SCRIPT2_NAME
-			&& opCommand != CMD_SCRIPT3
-			&& opCommand != CMD_SCRIPT3_NAME) {
-			return false;
-		}
-
 		// check parameter count for each operation case
 		if ((opCommand == CMD_READ && commandVector.size() != 2) ||
 			(opCommand == CMD_WRITE && commandVector.size() != 3) ||

--- a/TestShell/command_parser.h
+++ b/TestShell/command_parser.h
@@ -11,7 +11,8 @@ class CommandParser
 public:
 	void setCommand(const string& command);
 	const std::vector<std::string>& getCommandVector() const;
-	bool isValidCommand() const;
+	bool isValidOpCommand() const;
+	bool isValidCommandParameter() const;
 
 	static constexpr const char* CMD_READ = "read";
 	static constexpr const char* CMD_WRITE = "write";

--- a/TestShell/command_parser_test.cpp
+++ b/TestShell/command_parser_test.cpp
@@ -8,120 +8,120 @@ protected:
 
 TEST_F(CommandParserTest, ValidWriteCommand_ReturnsTrue) {
     parser.setCommand("write 3 0xABCDEF12");
-    EXPECT_TRUE(parser.isValidCommand());
+    EXPECT_TRUE(parser.isValidCommandParameter());
 }
 
 TEST_F(CommandParserTest, InvalidWriteCommand_BadValue_ReturnsFalse) {
     parser.setCommand("write 3 0xXYZ123");
-    EXPECT_FALSE(parser.isValidCommand());
+    EXPECT_FALSE(parser.isValidCommandParameter());
 }
 
 TEST_F(CommandParserTest, InvalidWriteCommand_LBAOutOfRange_ReturnsFalse) {
     parser.setCommand("write 123 0xABCDEF12");
-    EXPECT_FALSE(parser.isValidCommand());
+    EXPECT_FALSE(parser.isValidCommandParameter());
 }
 
 TEST_F(CommandParserTest, InvalidWriteCommand_MissingValue_ReturnsFalse) {
     parser.setCommand("write 3");
-    EXPECT_FALSE(parser.isValidCommand());
+    EXPECT_FALSE(parser.isValidCommandParameter());
 }
 
 TEST_F(CommandParserTest, ValidReadCommand_ReturnsTrue) {
     parser.setCommand("read 0");
-    EXPECT_TRUE(parser.isValidCommand());
+    EXPECT_TRUE(parser.isValidCommandParameter());
 }
 
 TEST_F(CommandParserTest, InvalidReadCommand_MissingArg_ReturnsFalse) {
     parser.setCommand("read");
-    EXPECT_FALSE(parser.isValidCommand());
+    EXPECT_FALSE(parser.isValidCommandParameter());
 }
 
 TEST_F(CommandParserTest, InvalidReadCommand_TooManyArgs_ReturnsFalse) {
     parser.setCommand("read 3 extra");
-    EXPECT_FALSE(parser.isValidCommand());
+    EXPECT_FALSE(parser.isValidCommandParameter());
 }
 
 TEST_F(CommandParserTest, ValidExitCommand_ReturnsTrue) {
     parser.setCommand("exit");
-    EXPECT_TRUE(parser.isValidCommand());
+    EXPECT_TRUE(parser.isValidCommandParameter());
 }
 
 TEST_F(CommandParserTest, ValidHelpCommand_ReturnsTrue) {
     parser.setCommand("help");
-    EXPECT_TRUE(parser.isValidCommand());
+    EXPECT_TRUE(parser.isValidCommandParameter());
 }
 
 TEST_F(CommandParserTest, ValidFullWriteCommand_ReturnsTrue) {
     parser.setCommand("fullwrite 0x1234ABCD");
-    EXPECT_TRUE(parser.isValidCommand());
+    EXPECT_TRUE(parser.isValidCommandParameter());
 }
 
 TEST_F(CommandParserTest, InvalidFullWriteCommand_BadValue_ReturnsFalse) {
     parser.setCommand("fullwrite 0xGIBBERISH");
-    EXPECT_FALSE(parser.isValidCommand());
+    EXPECT_FALSE(parser.isValidCommandParameter());
 }
 
 TEST_F(CommandParserTest, UnknownCommand_ReturnsFalse) {
     parser.setCommand("foobar");
-    EXPECT_FALSE(parser.isValidCommand());
+    EXPECT_FALSE(parser.isValidOpCommand());
 }
 
 TEST_F(CommandParserTest, EmptyInput_ReturnsFalse) {
     parser.setCommand("");
-    EXPECT_FALSE(parser.isValidCommand());
+    EXPECT_FALSE(parser.isValidOpCommand());
 }
 
 TEST_F(CommandParserTest, ExtraSpaces_StillValid) {
     parser.setCommand("   write   3    0x1234ABCD   ");
-    EXPECT_TRUE(parser.isValidCommand());
+    EXPECT_TRUE(parser.isValidCommandParameter());
 }
 
 TEST_F(CommandParserTest, ExtraSpacesTab_StillValid) {
     parser.setCommand("   write   3                     0x1234ABCD   ");
-    EXPECT_TRUE(parser.isValidCommand());
+    EXPECT_TRUE(parser.isValidCommandParameter());
 }
 
 TEST_F(CommandParserTest, ValidScript1ShortCommand_ReturnsTrue) {
     parser.setCommand("1_");
-    EXPECT_TRUE(parser.isValidCommand());
+    EXPECT_TRUE(parser.isValidCommandParameter());
 }
 
 TEST_F(CommandParserTest, ValidScript1FullCommand_ReturnsTrue) {
     parser.setCommand("1_FullWriteAndReadCompare");
-    EXPECT_TRUE(parser.isValidCommand());
+    EXPECT_TRUE(parser.isValidCommandParameter());
 }
 
 TEST_F(CommandParserTest, ValidScript2ShortCommand_ReturnsTrue) {
     parser.setCommand("2_");
-    EXPECT_TRUE(parser.isValidCommand());
+    EXPECT_TRUE(parser.isValidCommandParameter());
 }
 
 TEST_F(CommandParserTest, ValidScript2FullCommand_ReturnsTrue) {
     parser.setCommand("2_PartialLBAWrite");
-    EXPECT_TRUE(parser.isValidCommand());
+    EXPECT_TRUE(parser.isValidCommandParameter());
 }
 
 TEST_F(CommandParserTest, ValidScript3ShortCommand_ReturnsTrue) {
     parser.setCommand("3_");
-    EXPECT_TRUE(parser.isValidCommand());
+    EXPECT_TRUE(parser.isValidCommandParameter());
 }
 
 TEST_F(CommandParserTest, ValidScript3FullCommand_ReturnsTrue) {
     parser.setCommand("3_WriteReadAging");
-    EXPECT_TRUE(parser.isValidCommand());
+    EXPECT_TRUE(parser.isValidCommandParameter());
 }
 
 TEST_F(CommandParserTest, Script1CommandWithExtraArgs_ReturnsFalse) {
     parser.setCommand("1_ extraArg");
-    EXPECT_FALSE(parser.isValidCommand());
+    EXPECT_FALSE(parser.isValidCommandParameter());
 }
 
 TEST_F(CommandParserTest, Script2CommandWithExtraArgs_ReturnsFalse) {
     parser.setCommand("2_PartialLBAWrite unexpected");
-    EXPECT_FALSE(parser.isValidCommand());
+    EXPECT_FALSE(parser.isValidCommandParameter());
 }
 
 TEST_F(CommandParserTest, Script3CommandWithExtraArgs_ReturnsFalse) {
     parser.setCommand("3_WriteReadAging junk1 junk2");
-    EXPECT_FALSE(parser.isValidCommand());
+    EXPECT_FALSE(parser.isValidCommandParameter());
 }

--- a/TestShell/test_shell.cpp
+++ b/TestShell/test_shell.cpp
@@ -45,9 +45,6 @@ bool TestShell::ExecuteCommand(vector<string> commandVector)
         std::cout << "Running script 3: WriteReadAging" << std::endl;
         // TestScript3::writeReadAging();
     }
-    else {
-        std::cout << "[Error] Unknown command: " << opCommand << std::endl;
-    }
 
     return true;
 }
@@ -64,8 +61,13 @@ void TestShell::runShell()
 
         commandParser.setCommand(inputLine);
 
-        if (!commandParser.isValidCommand()) {
-            std::cout << "[Error] Invalid command or arguments." << std::endl;
+        if (!commandParser.isValidOpCommand()) {
+            std::cout << "INVALID COMMAND" << std::endl;
+            continue;
+        }
+
+        if (!commandParser.isValidCommandParameter()) {
+            std::cout << "INVALID PARAMETER" << std::endl;
             continue;
         }
 


### PR DESCRIPTION
## 📌 PR 제목
- [Bug Fix] Print INVALID COMMAND at TestShell when receiving invalid command opcode

## 📄 변경 사항
- PDF 명세에 따라 없는 명령어를 수행하는 경우 "INVALID COMMAND" 로 프린트하도록 수정하였습니다.

## 🔍 상세 설명
- 기존에 Command Parser 에서 OpCode와 Parameter를 같이 Verify 하던 것을 함수를 나누어 각각에 해당하는 Error Message를 return하도록 수정하였습니다.

## ✅ 체크리스트
- [ ] 코드 스타일을 따랐는가?
- [ ] 테스트를 작성했는가?
- [ ] master branch 리베이스 후 빌드 확인 하였는가?