### PR TITLE
[fix] SSD: fix to write to ../ssd_nand.txt

### DIFF
--- a/SSD/file_interface.cpp
+++ b/SSD/file_interface.cpp
@@ -5,10 +5,26 @@ FileInterface::FileInterface(const std::string& file) {
 }
 
 bool FileInterface::fileOpen() {
-	ssdNandFile.open(fileName, std::ios::in | std::ios::out | std::ios::app);
+	if (ssdNandFile.is_open())
+		ssdNandFile.close();
+
+	ssdNandFile.open(fileName, std::ios::in | std::ios::out);
+
+	if (!ssdNandFile.is_open()) {
+		std::cout << "[Debug] Creating new file: " << fileName << std::endl;
+
+		std::ofstream create(fileName);
+		create.close();
+
+		ssdNandFile.open(fileName, std::ios::in | std::ios::out);
+	}
+
 	readPoint = 0;
-	return ssdNandFile.is_open();
+	bool is_open = ssdNandFile.is_open();
+	std::cout << "[Debug] fileOpen: is_open=" << is_open << std::endl;
+	return is_open;
 }
+
 bool FileInterface::fileReadOneline(std::string& str) {
 	if (!ssdNandFile.is_open()) return false;
 
@@ -24,16 +40,24 @@ bool FileInterface::setReadPoint(unsigned point) {
 	readPoint = point;
 	return ssdNandFile.good();
 }
+
 bool FileInterface::fileWriteOneline(const std::string str) {
 	if (!ssdNandFile.is_open()) return false;
 
-	ssdNandFile.seekg(0, std::ios::end);
 	ssdNandFile << str << '\n';
+
+	if (!ssdNandFile.good()) {
+		std::cout << "[Error] write failed: fail=" << ssdNandFile.fail()
+			<< ", bad=" << ssdNandFile.bad() << std::endl;
+	}
+
 	return ssdNandFile.good();
 }
+
 void FileInterface::fileClose() {
 	ssdNandFile.close();
 }
+
 bool FileInterface::fileRemove() {
 	std::ofstream file(fileName, std::ios::trunc);
 	if (file.is_open()) {

--- a/SSD/ssd_test.cpp
+++ b/SSD/ssd_test.cpp
@@ -55,7 +55,7 @@ TEST_F(SSDTestFixture, ReadTest) {
 
 	app.run("R 0");
 
-	FileInterface nandFile = { "ssd_nand.txt" };
+	FileInterface nandFile = { "../ssd_nand.txt" };
 	string expected;
 	nandFile.fileOpen();
 	nandFile.fileReadOneline(expected);

--- a/TestShell/shell_read_test.cpp
+++ b/TestShell/shell_read_test.cpp
@@ -14,7 +14,7 @@ public:
 	const string EXPECT_AA = "0xAAAAAAAA";
 
 	void ssdReadFileSetUp() {
-		std::string filePath = "ssd_output.txt";
+		std::string filePath = "../ssd_output.txt";
 		std::ofstream outfile(filePath);
 		outfile << EXPECT_AA << std::endl;
 		outfile.close();

--- a/TestShell/shell_write_test.cpp
+++ b/TestShell/shell_write_test.cpp
@@ -87,7 +87,7 @@ TEST_F(WriteTestFixture, TestRealSSDWrite) {
 	TestShell shell{ &realSSD };
 	shell.write(VALID_LBA, value);
 	EXPECT_EQ(WRITE_DONE, oss.str());
-	std::ifstream nand("ssd_nand.txt");
+	std::ifstream nand("../ssd_nand.txt");
 	ASSERT_TRUE(nand.is_open());
 	std::string line;
 	std::vector<string> outputData;

--- a/TestShell/ssd_interface.h
+++ b/TestShell/ssd_interface.h
@@ -57,7 +57,7 @@ public:
 		return content;
 	}
 private:
-	const string SSD_READ_RESULT = "ssd_output.txt";
+	const string SSD_READ_RESULT = "../ssd_output.txt";
 };
 
 class MockSSDDriver : public SSDDriver {


### PR DESCRIPTION
## 📌 PR 제목
- [fix] SSD.exe read/write 수정

## 📄 변경 사항
- FileInterface::fileOpen() 로직 개선
- 존재하지 않는 ssd_nand.txt 파일에 대해 쓰기 실패 문제 수정

## 🔍 상세 설명
- 기존 코드에서 fstream을 std::ios::in | std::ios::out 모드로 열 때,
대상 파일(../ssd_nand.txt)이 존재하지 않으면 failbit, badbit가 set되어 쓰기가 실패하는 문제가 있었습니다.
따라서 fileOpen() 내에서 파일이 없으면 std::ofstream 으로 먼저 생성 후 다시 읽기/쓰기 모드로 여는 로직을 추가했습니다.
이를 통해 SSD 명령어 W 실행 시, ssd_nand.txt가 없더라도 자동 생성 및 정상적인 write가 가능해졌습니다.

## ✅ 체크리스트
- [ ] 코드 스타일을 따랐는가?
- [ ] 테스트를 작성했는가?
- [ ] master branch 리베이스 후 빌드 확인 하였는가?