### PR TITLE
[feature] Add writeAllLines and readAllLines to file util

### DIFF
--- a/TestShell/TestShell.vcxproj
+++ b/TestShell/TestShell.vcxproj
@@ -129,7 +129,6 @@
     <ClCompile Include="command_parser_test.cpp" />
     <ClCompile Include="file_util.cpp" />
     <ClCompile Include="file_util_test.cpp" />
-    <ClCompile Include="concrete_commands.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="ssd_interface.cpp" />
     <ClCompile Include="testshell_execute_command_test.cpp">

--- a/TestShell/file_util.cpp
+++ b/TestShell/file_util.cpp
@@ -46,3 +46,30 @@ bool FileUtil::clearFile(const std::string& filePath) {
     std::ofstream ofs(filePath.c_str(), std::ios::trunc);
     return ofs.is_open();
 }
+
+bool FileUtil::writeAllLines(const std::string& filePath, const std::vector<std::string>& lines, bool append) {
+    std::ofstream ofs;
+    if (append)
+        ofs.open(filePath.c_str(), std::ios::app);
+    else
+        ofs.open(filePath.c_str(), std::ios::trunc);
+
+    if (!ofs.is_open()) return false;
+
+    for (const auto& line : lines) {
+        ofs << line << std::endl;
+        if (!ofs.good()) return false;
+    }
+    return true;
+}
+
+bool FileUtil::readAllLines(const std::string& filePath, std::vector<std::string>& linesOut) {
+    std::ifstream ifs(filePath.c_str());
+    if (!ifs.is_open()) return false;
+
+    std::string line;
+    while (std::getline(ifs, line)) {
+        linesOut.push_back(line);
+    }
+    return ifs.eof();
+}

--- a/TestShell/file_util.h
+++ b/TestShell/file_util.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 class FileUtil {
 public:
@@ -10,4 +11,7 @@ public:
     static bool writeLine(const std::string& filePath, const std::string& line, bool append = true);
     static bool readLine(const std::string& filePath, std::string& lineOut);
     static bool clearFile(const std::string& filePath);
+    static bool writeAllLines(const std::string& filePath, const std::vector<std::string>& lines, bool append = false);
+    static bool readAllLines(const std::string& filePath, std::vector<std::string>& linesOut);
+
 };

--- a/TestShell/file_util_test.cpp
+++ b/TestShell/file_util_test.cpp
@@ -52,3 +52,33 @@ TEST_F(FileUtilTest, ReadLineFailsOnEmptyFile) {
     bool result = FileUtil::readLine(testFile, line);
     EXPECT_FALSE(result);
 }
+
+TEST_F(FileUtilTest, WriteAndReadAllLines) {
+    std::vector<std::string> inputLines = {
+        "Line 1", "Line 2", "Line 3"
+    };
+
+    ASSERT_TRUE(FileUtil::writeAllLines(testFile, inputLines));
+
+    std::vector<std::string> outputLines;
+    ASSERT_TRUE(FileUtil::readAllLines(testFile, outputLines));
+
+    ASSERT_EQ(inputLines.size(), outputLines.size());
+    for (size_t i = 0; i < inputLines.size(); ++i) {
+        EXPECT_EQ(inputLines[i], outputLines[i]);
+    }
+}
+
+TEST_F(FileUtilTest, AppendLines) {
+    std::vector<std::string> firstLines = { "A", "B" };
+    std::vector<std::string> secondLines = { "C", "D" };
+
+    ASSERT_TRUE(FileUtil::writeAllLines(testFile, firstLines, /*append=*/true));
+    ASSERT_TRUE(FileUtil::writeAllLines(testFile, secondLines, /*append=*/true));
+
+    std::vector<std::string> resultLines;
+    ASSERT_TRUE(FileUtil::readAllLines(testFile, resultLines));
+
+    std::vector<std::string> expected = { "A", "B", "C", "D" };
+    ASSERT_EQ(resultLines, expected);
+}


### PR DESCRIPTION
## 📌 PR 제목
- [feature] Add writeAllLines and readAllLines to file util

## 📄 변경 사항
- FileUtil 클래스에 writeAllLines, readAllLines 함수 추가

## 🔍 상세 설명
- 기존 writeLine, readLine 함수는 한 줄씩만 처리 가능
- 여러 줄을 한 번에 읽거나 쓰는 기능이 필요해 std::vector<std::string>을 입력/출력으로 받는 API 추가
- append 모드 지원으로 로그 누적 작성 등 활용 가능
- 사용자가 파일 열고 닫는 것을 신경 쓰지 않도록 함수 내부에서 open/close 처리
- FileUtilTest 픽스처 기반으로 다음 항목 테스트 추가:
여러 줄 쓰고 다시 읽었을 때 내용 일치하는지 확인
append = true 옵션으로 여러 번 쓰고 전체 줄이 누적됐는지 확인

## ✅ 체크리스트
- [x] 코드 스타일을 따랐는가?
- [x] 테스트를 작성했는가?
- [x] master branch 리베이스 후 빌드 확인 하였는가?
