### PR TITLE
[fix] fix to use correct arguments

### DIFF
--- a/TestShell/command.cpp
+++ b/TestShell/command.cpp
@@ -3,7 +3,7 @@
 
 bool ReadCommand::execute(const std::vector<std::string>& args)
 {
-	int lba = std::stoi(args.at(0));
+	int lba = std::stoi(args.at(1));
 	std::cout << "Executing read from LBA " << lba << std::endl;
 	read(lba);
     return true;
@@ -28,8 +28,8 @@ void ReadCommand::ssdReadAndPrint(int addr)
 
 bool WriteCommand::execute(const std::vector<std::string>& args)
 {
-	int lba = std::stoi(args.at(0));
-	std::string value = args.at(1);
+	int lba = std::stoi(args.at(1));
+	std::string value = args.at(2);
 	std::cout << "Executing write to LBA " << lba << " with value " << value << std::endl;
 	write(lba, value);
     return true;


### PR DESCRIPTION
arg[0] : command like read/write
arg[1] : lba if exist

## 📌 PR 제목
- [fix] fix to use correct arguments

## 📄 변경 사항
- command parser가 return하는 vector값의 0번째가 read/write 같은 command여서, 수정합니다.

## 🔍 상세 설명
- 해당 수정사항 없는 경우 stoi 단계에서 runtime error 발생하여 수정합니다.

## ✅ 체크리스트
- [x] 코드 스타일을 따랐는가?
- [ ] 테스트를 작성했는가?
- [x] master branch 리베이스 후 빌드 확인 하였는가?