### PR TITLE
Refactoring/test shell command remained

### DIFF
--- a/TestShell/command.cpp
+++ b/TestShell/command.cpp
@@ -51,7 +51,21 @@ void WriteCommand::write(int lba, std::string value)
 
 bool FullReadCommand::execute(const std::vector<std::string>& args)
 {
+	std::cout << "Executing fullread" << std::endl;
+	fullRead();
     return false;
+}
+
+void FullReadCommand::fullRead()
+{
+	try {
+		for (int addr = 0; addr < MAX_LBA; addr++) {
+			ssdReadAndPrint(addr);
+		}
+	}
+	catch (std::exception e) {
+		std::cout << string(e.what());
+	}
 }
 
 bool FullWriteCommand::execute(const std::vector<std::string>& args)

--- a/TestShell/command.cpp
+++ b/TestShell/command.cpp
@@ -56,7 +56,21 @@ bool FullReadCommand::execute(const std::vector<std::string>& args)
 
 bool FullWriteCommand::execute(const std::vector<std::string>& args)
 {
+	std::string value = args.at(0);
+	std::cout << "Executing fullwrite with value " << value << std::endl;
+	fullWrite(value);
     return false;
+}
+void FullWriteCommand::fullWrite(std::string value) {
+	if (ssd == nullptr) return;
+	try {
+		for (int i = 0; i < 100; i++)
+			ssd->write(i, value);
+		std::cout << "[FULL_WRITE] Done" << std::endl;
+	}
+	catch (SSDExecutionException& e) {
+		std::cout << "[FULL_WRITE] Fail" << std::endl;
+	}
 }
 
 bool ExitCommand::execute(const std::vector<std::string>& args)

--- a/TestShell/command.cpp
+++ b/TestShell/command.cpp
@@ -89,7 +89,7 @@ void FullWriteCommand::fullWrite(std::string value) {
 
 bool ExitCommand::execute(const std::vector<std::string>& args)
 {
-    return true;
+    return false;
 }
 
 bool HelpCommand::execute(const std::vector<std::string>& args)

--- a/TestShell/command.cpp
+++ b/TestShell/command.cpp
@@ -53,7 +53,7 @@ bool FullReadCommand::execute(const std::vector<std::string>& args)
 {
 	std::cout << "Executing fullread" << std::endl;
 	fullRead();
-    return false;
+    return true;
 }
 
 void FullReadCommand::fullRead()
@@ -73,7 +73,7 @@ bool FullWriteCommand::execute(const std::vector<std::string>& args)
 	std::string value = args.at(0);
 	std::cout << "Executing fullwrite with value " << value << std::endl;
 	fullWrite(value);
-    return false;
+    return true;
 }
 void FullWriteCommand::fullWrite(std::string value) {
 	if (ssd == nullptr) return;
@@ -89,7 +89,7 @@ void FullWriteCommand::fullWrite(std::string value) {
 
 bool ExitCommand::execute(const std::vector<std::string>& args)
 {
-    return false;
+    return true;
 }
 
 bool HelpCommand::execute(const std::vector<std::string>& args)
@@ -124,19 +124,4 @@ bool HelpCommand::execute(const std::vector<std::string>& args)
 	std::cout << "\t\tMust contain exactly 8 hex digits (0-9, A-F)\n";
 	std::cout << "\t\tExample: 0x12345678, 0xDEADBEEF\n\n";
     return true;
-}
-
-bool TestScript1Command::execute(const std::vector<std::string>& args)
-{
-    return false;
-}
-
-bool TestScript2Command::execute(const std::vector<std::string>& args)
-{
-    return false;
-}
-
-bool TestScript3Command::execute(const std::vector<std::string>& args)
-{
-    return false;
 }

--- a/TestShell/command.h
+++ b/TestShell/command.h
@@ -9,6 +9,8 @@ public:
     virtual 
     virtual ~Command() = default;
     virtual bool execute(const std::vector<std::string>& args) = 0;
+
+    const static int MAX_LBA = 100;
 };
 
 // concreate commands
@@ -16,6 +18,8 @@ class ReadCommand : public Command {
 public:
     ReadCommand(SSDInterface* ssd) : ssd(ssd) {}
     bool execute(const std::vector<std::string>& args) override;
+protected:
+    void ssdReadAndPrint(int addr);
 private:
     SSDInterface* ssd;
     const string READ_HEADER = "[Read] LBA ";
@@ -23,7 +27,6 @@ private:
     const string READ_FOOTER = "\n";
 
     void read(int lba);
-    void ssdReadAndPrint(int addr);
 };
 class WriteCommand : public Command {
 public:
@@ -34,9 +37,13 @@ private:
 
     void write(int lba, std::string value);
 };
-class FullReadCommand : public Command {
+class FullReadCommand : public ReadCommand {
 public:
+    FullReadCommand(SSDInterface* ssd) : ReadCommand(ssd) {}
     bool execute(const std::vector<std::string>& args) override;
+private:
+
+    void fullRead();
 };
 class FullWriteCommand : public Command {
 public:

--- a/TestShell/command.h
+++ b/TestShell/command.h
@@ -40,7 +40,12 @@ public:
 };
 class FullWriteCommand : public Command {
 public:
+    FullWriteCommand(SSDInterface* ssd) : ssd(ssd) {}
     bool execute(const std::vector<std::string>& args) override;
+private:
+    SSDInterface* ssd;
+
+    void fullWrite(std::string value);
 };
 class ExitCommand : public Command {
 public:

--- a/TestShell/command.h
+++ b/TestShell/command.h
@@ -62,18 +62,6 @@ class HelpCommand : public Command {
 public:
     bool execute(const std::vector<std::string>& args) override;
 };
-class TestScript1Command : public Command {
-public:
-    bool execute(const std::vector<std::string>& args) override;
-};
-class TestScript2Command : public Command {
-public:
-    bool execute(const std::vector<std::string>& args) override;
-};
-class TestScript3Command : public Command {
-public:
-    bool execute(const std::vector<std::string>& args) override;
-};
 
 // command Factory
 

--- a/TestShell/common_test_fixture.h
+++ b/TestShell/common_test_fixture.h
@@ -26,4 +26,17 @@ public:
 			return str;
 		}
 	}
+	std::string excludeFirstLine(const std::string& str) {
+		if (str.empty()) {
+			return "";
+		}
+
+		size_t firstNewlinePos = str.find('\n');
+
+		if (firstNewlinePos == std::string::npos) {
+			return "";
+		}
+
+		return str.substr(firstNewlinePos + 1);
+	}
 };

--- a/TestShell/shell_read_test.cpp
+++ b/TestShell/shell_read_test.cpp
@@ -51,13 +51,16 @@ TEST_F(TestShellRead, FullReadPassWithMockSSD) {
 		.Times(100)
 		.WillRepeatedly(Return(EXPECT_AA));
 
-	shell.setSSD(&mockSSD);
+//	shell.setSSD(&mockSSD);
+	FullReadCommand cmd{ &mockSSD };
 
 	std::ostringstream oss;
 	auto oldCoutStreamBuf = std::cout.rdbuf();
 	std::cout.rdbuf(oss.rdbuf());
 
-	shell.fullRead();
+	vector<string> args = {};
+//	shell.fullRead();
+	cmd.execute(args);
 	std::cout.rdbuf(oldCoutStreamBuf);
 
 	string expect = "";
@@ -72,7 +75,7 @@ TEST_F(TestShellRead, FullReadPassWithMockSSD) {
 		expect += FOOTER;
 	}
 
-	EXPECT_EQ(expect, oss.str());
+	EXPECT_EQ(expect, excludeFirstLine(oss.str()));
 }
 
 
@@ -129,13 +132,15 @@ TEST_F(TestShellRead, FullReadPassWithMockRunExe) {
 		.Times(100)
 		.WillRepeatedly(Return(true));
 
-	shell.setSSD(&SSDwithMockRunExe);
+	FullReadCommand cmd{ &SSDwithMockRunExe };
 
 	std::ostringstream oss;
 	auto oldCoutStreamBuf = std::cout.rdbuf();
 	std::cout.rdbuf(oss.rdbuf());
 
-	shell.fullRead();
+	vector<string> args = {};
+	//	shell.fullRead();
+	cmd.execute(args);
 	std::cout.rdbuf(oldCoutStreamBuf);
 
 	string expect = "";
@@ -150,7 +155,7 @@ TEST_F(TestShellRead, FullReadPassWithMockRunExe) {
 		expect += FOOTER;
 	}
 
-	EXPECT_EQ(expect, oss.str());
+	EXPECT_EQ(expect, excludeFirstLine(oss.str()));
 }
 
 //TEST_F(TestShellRead, ReadFailWithMockRunExe) {

--- a/TestShell/shell_write_test.cpp
+++ b/TestShell/shell_write_test.cpp
@@ -12,7 +12,8 @@ public:
 	MockSSD mockSSD;
 	SSDDriver realSSD;
 	MockSSDDriver mockSSDDriver;
-	WriteCommand cmd{ &mockSSD };
+	WriteCommand writeCmd{ &mockSSD };
+	FullWriteCommand fullWriteCmd{ &mockSSD };
 	std::string value = "0x12345678";
 	std::ostringstream oss;
 	std::streambuf* oldCoutStreamBuf;
@@ -27,7 +28,11 @@ public:
 	}
 	void executeWrite(int lba, string value) {
 		vector<string> args = { std::to_string(lba), value };
-		cmd.execute(args);
+		writeCmd.execute(args);
+	}
+	void executeFullWrite(string value) {
+		vector<string> args = { value };
+		fullWriteCmd.execute(args);
 	}
 protected:
 	void SetUp() override {
@@ -66,15 +71,17 @@ TEST_F(WriteTestFixture, TestInvalidSSD) {
 	shell.write(VALID_LBA, value);
 	EXPECT_CALL(mockSSD, write).Times(0);
 }
+#endif
 
 TEST_F(WriteTestFixture, TestFullWrite) {
-	TestShell shell{ &mockSSD };
 	for (int i = 0; i < 100; i++)
 		EXPECT_CALL(mockSSD, write(i, value)).Times(1);
-	shell.fullWrite(value);
-	EXPECT_EQ(FULL_WRITE_DONE, oss.str());
+	
+	executeFullWrite(value);
+	EXPECT_EQ(FULL_WRITE_DONE, getLastLine(oss.str()));
 }
 
+#if 0
 TEST_F(WriteTestFixture, TestRealSSDWriteFail) {
 	if (isFileExists(SSD_EXE_FILE)) {
 		GTEST_SKIP() << SSD_EXE_FILE << " not found, skipping test.";

--- a/TestShell/test_script.h
+++ b/TestShell/test_script.h
@@ -3,10 +3,16 @@
 #include <string>
 
 #include "ssd_interface.h"
+#include "command.h"
 
-class ScriptsCommand {
+class ScriptsCommand : public Command{
 public:
 	ScriptsCommand(SSDInterface* device) : ssd(device) {}
+	bool execute(const std::vector<std::string>& args) override { 
+		if (run()) result = "TRUE";
+		std::cout << result << '\n';
+		return true; 
+	};
 	virtual bool run() = 0;
 
 protected:
@@ -14,6 +20,7 @@ protected:
 	std::string intToHexString(int hexValue) const;
 	bool readCompare(int address, std::string hexValue) const;
 
+	string result = "FAIL";
 	SSDInterface* ssd;
 };
 

--- a/TestShell/test_shell.cpp
+++ b/TestShell/test_shell.cpp
@@ -28,9 +28,8 @@ bool TestShell::ExecuteCommand(vector<string> commandVector)
         if (!command->execute(commandVector)) return false;
     }
     else if (opCommand == CommandParser::CMD_FULLWRITE) {
-        std::string value = commandVector.at(1);
-        std::cout << "Executing fullwrite with value " << value << std::endl;
-        fullWrite(value);
+        Command* command = new FullWriteCommand(ssd);
+        if (!command->execute(commandVector)) return false;
     }
     else if (opCommand == CommandParser::CMD_FULLREAD) {
         std::cout << "Executing fullread" << std::endl;
@@ -158,19 +157,6 @@ void TestShell::ssdReadAndPrint(int addr)
 
     cout << READ_HEADER << oss.str() << READ_MIDFIX << content << READ_FOOTER;
 }
-
-void TestShell::fullWrite(std::string value) {
-    if (ssd == nullptr) return;
-	try {
-		for (int i = 0; i < 100; i++)
-			ssd->write(i, value);
-		std::cout << "[FULL_WRITE] Done" << std::endl;
-	}
-	catch (SSDExecutionException& e) {
-		std::cout << "[FULL_WRITE] Fail" << std::endl;
-	}
-}
-
 void TestShell::erase(int lba, int size) {
     try {
         // lba : 0 <= lba < 100, size : -INT_MAX ~ INT_MAX

--- a/TestShell/test_shell.cpp
+++ b/TestShell/test_shell.cpp
@@ -32,8 +32,8 @@ bool TestShell::ExecuteCommand(vector<string> commandVector)
         if (!command->execute(commandVector)) return false;
     }
     else if (opCommand == CommandParser::CMD_FULLREAD) {
-        std::cout << "Executing fullread" << std::endl;
-        fullRead();
+        Command* command = new FullReadCommand(ssd);
+        if (!command->execute(commandVector)) return false;
     }
     else if (opCommand == CommandParser::CMD_ERASE) {
         int lba = std::stoi(commandVector.at(1));
@@ -135,27 +135,6 @@ void TestShell::runScript(std::string filename)
     }
 
     scriptListFile.close();
-}
-
-void TestShell::fullRead()
-{
-    try {
-	    for (int addr = 0; addr < MAX_LBA; addr++) {       
-            ssdReadAndPrint(addr);
-	    }
-    }
-    catch (std::exception e) {
-        cout << string(e.what());
-    }
-}
-
-void TestShell::ssdReadAndPrint(int addr)
-{
-    std::string content = ssd->read(addr);
-    std::ostringstream oss;
-    oss << std::setw(2) << std::setfill('0') << addr;
-
-    cout << READ_HEADER << oss.str() << READ_MIDFIX << content << READ_FOOTER;
 }
 void TestShell::erase(int lba, int size) {
     try {

--- a/TestShell/test_shell.cpp
+++ b/TestShell/test_shell.cpp
@@ -9,6 +9,7 @@ using std::cout;
 bool TestShell::ExecuteCommand(vector<string> commandVector)
 {
     std::string opCommand = commandVector.at(0);
+
     string result = "FAIL";
 
     if (opCommand == CommandParser::CMD_EXIT) {
@@ -46,28 +47,22 @@ bool TestShell::ExecuteCommand(vector<string> commandVector)
         flush();
     }
     else if (opCommand == CommandParser::CMD_SCRIPT1 || opCommand == CommandParser::CMD_SCRIPT1_NAME) {
-        ScriptsCommand* scriptCommand = new ScriptsFullWriteAndReadCompare(ssd);
-
         std::cout << "Running script 1: FullWriteAndReadCompare" << std::endl;
-        if (scriptCommand->run()) result = "TRUE";
-
-        std::cout << result << '\n';
-    }
-    else if (opCommand == CommandParser::CMD_SCRIPT2 || opCommand == CommandParser::CMD_SCRIPT2_NAME) {
-        ScriptsCommand* scriptCommand = new ScriptsPartialLBAWrite(ssd);
         
+        Command* command = new ScriptsFullWriteAndReadCompare(ssd);
+        if (!command->execute(commandVector)) return false;
+ }
+    else if (opCommand == CommandParser::CMD_SCRIPT2 || opCommand == CommandParser::CMD_SCRIPT2_NAME) {
         std::cout << "Running script 2: PartialLBAWrite" << std::endl;
-        if (scriptCommand->run()) result = "TRUE";
-
-        std::cout << result << '\n';
+        
+        Command* command = new ScriptsPartialLBAWrite(ssd);
+        if (!command->execute(commandVector)) return false;
     }
     else if (opCommand == CommandParser::CMD_SCRIPT3 || opCommand == CommandParser::CMD_SCRIPT3_NAME) {
-        ScriptsCommand* scriptCommand = new ScriptsWriteReadAging(ssd);
-
         std::cout << "Running script 3: WriteReadAging" << std::endl;
-        if (scriptCommand->run()) result = "TRUE";
 
-        std::cout << result << '\n';
+        Command* command = new ScriptsWriteReadAging(ssd);
+        if (!command->execute(commandVector)) return false;
     }
     else {
         std::cout << "[Error] Unknown command: " << opCommand << std::endl;

--- a/TestShell/test_shell.h
+++ b/TestShell/test_shell.h
@@ -20,7 +20,7 @@ public:
 //	virtual void read(int lba);
 	virtual void fullRead();
 //	virtual void write(int lba, std::string value);
-	virtual void fullWrite(std::string value);
+//	virtual void fullWrite(std::string value);
 	virtual void erase(int lba, int size);
 	virtual void flush();
 

--- a/TestShell/test_shell.h
+++ b/TestShell/test_shell.h
@@ -16,21 +16,10 @@ public:
 	void runShell();
 	void runScript(std::string filename);
 	bool ExecuteCommand(vector<string> commandVector);
-
-//	virtual void read(int lba);
-	virtual void fullRead();
-//	virtual void write(int lba, std::string value);
-//	virtual void fullWrite(std::string value);
 	virtual void erase(int lba, int size);
 	virtual void flush();
 
 private:
 	SSDInterface* ssd;
 	CommandParser commandParser;
-	const int MAX_LBA = 100;
-	const string READ_HEADER = "[Read] LBA ";
-	const string READ_MIDFIX = " : ";
-	const string READ_FOOTER = "\n";
-
-	void ssdReadAndPrint(int addr);
 };


### PR DESCRIPTION
## 📌 PR 제목
- [Refactoring] fullread, fullwrite, testscript 들도 command pattern으로 적용

## 📄 변경 사항
- 기존 command 들 중 fullread, fullwrite, testscript commands들도 command class를 상속 받도록 정리하였습니다.

## 🔍 상세 설명
- fullread는 read command와 동일하게 사용하는 부분이 많아 read command를 상속받도록 하였습니다.
- erase, flush까지 작업 완료되면 factory method 반영 예정입니다.

## ✅ 체크리스트
- [x] 코드 스타일을 따랐는가?
- [x] 테스트를 작성했는가?
- [ ] master branch 리베이스 후 빌드 확인 하였는가?