### PR TITLE
Refactoring/test shell make command factory

### DIFF
--- a/TestShell/TestShell.vcxproj
+++ b/TestShell/TestShell.vcxproj
@@ -125,6 +125,7 @@
   <ItemGroup>
     <ClCompile Include="command.cpp" />
     <ClCompile Include="command.h" />
+    <ClCompile Include="command_factory.cpp" />
     <ClCompile Include="command_parser.cpp" />
     <ClCompile Include="command_parser_test.cpp" />
     <ClCompile Include="file_util.cpp" />
@@ -153,6 +154,7 @@
     <ClCompile Include="shell_help_test.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="command_factory.h" />
     <ClInclude Include="command_parser.h" />
     <ClInclude Include="file_util.h" />
     <ClInclude Include="common_test_fixture.h" />

--- a/TestShell/TestShell.vcxproj.filters
+++ b/TestShell/TestShell.vcxproj.filters
@@ -87,6 +87,9 @@
     <ClCompile Include="shell_run_script_test.cpp">
       <Filter>테스트 파일</Filter>
     </ClCompile>
+    <ClCompile Include="command_factory.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ssd_interface.h">
@@ -108,6 +111,9 @@
       <Filter>테스트 파일</Filter>
     </ClInclude>
     <ClInclude Include="logger.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="command_factory.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>

--- a/TestShell/command.cpp
+++ b/TestShell/command.cpp
@@ -1,7 +1,5 @@
 #include "command.h"
-#include "test_script.h"
 #include <iostream>
-#include "command_parser.h"
 
 bool ReadCommand::execute(const std::vector<std::string>& args)
 {
@@ -200,51 +198,4 @@ void FlushCommand::flush() {
 	catch (SSDExecutionException& e) {
 		std::cout << "[FLUSH] Fail" << std::endl;
 	}
-}
-
-std::unique_ptr<Command> CommandFactory::createCommand(const std::vector<std::string>& commandVector, SSDInterface* ssd) {
-	if (commandVector.empty()) {
-		return nullptr;
-	}
-
-	std::string opCommand = commandVector.at(0);
-
-	if (opCommand == CommandParser::CMD_EXIT) {
-		return std::make_unique<ExitCommand>();
-	}
-	else if (opCommand == CommandParser::CMD_HELP) {
-		return std::make_unique<HelpCommand>();
-	}
-	else if (opCommand == CommandParser::CMD_WRITE) {
-		return std::make_unique<WriteCommand>(ssd);
-	}
-	else if (opCommand == CommandParser::CMD_READ) {
-		return std::make_unique<ReadCommand>(ssd);
-	}
-	else if (opCommand == CommandParser::CMD_FULLWRITE) {
-		return std::make_unique<FullWriteCommand>(ssd);
-	}
-	else if (opCommand == CommandParser::CMD_FULLREAD) {
-		return std::make_unique<FullReadCommand>(ssd);
-	}
-	else if (opCommand == CommandParser::CMD_ERASE) {
-		//
-	}
-	else if (opCommand == CommandParser::CMD_ERASE_RANGE) {
-		//
-	}
-	else if (opCommand == CommandParser::CMD_FLUSH) {
-		//
-	}
-	else if (opCommand == CommandParser::CMD_SCRIPT1 || opCommand == CommandParser::CMD_SCRIPT1_NAME) {
-		return std::make_unique<ScriptsFullWriteAndReadCompare>(ssd);
-	}
-	else if (opCommand == CommandParser::CMD_SCRIPT2 || opCommand == CommandParser::CMD_SCRIPT2_NAME) {
-		return std::make_unique<ScriptsPartialLBAWrite>(ssd);
-	}
-	else if (opCommand == CommandParser::CMD_SCRIPT3 || opCommand == CommandParser::CMD_SCRIPT3_NAME) {
-		return std::make_unique<ScriptsWriteReadAging>(ssd);
-	}
-
-	return nullptr;
 }

--- a/TestShell/command.cpp
+++ b/TestShell/command.cpp
@@ -70,7 +70,7 @@ void FullReadCommand::fullRead()
 
 bool FullWriteCommand::execute(const std::vector<std::string>& args)
 {
-	std::string value = args.at(1);
+	std::string value = args.at(0);
 	std::cout << "Executing fullwrite with value " << value << std::endl;
 	fullWrite(value);
     return true;
@@ -129,8 +129,8 @@ bool HelpCommand::execute(const std::vector<std::string>& args)
 
 bool EraseCommand::execute(const std::vector<std::string>& args)
 {
-	int lba = std::stoi(args.at(1));
-	int size = std::stoi(args.at(2));
+	int lba = std::stoi(args.at(0));
+	int size = std::stoi(args.at(1));
 	std::cout << "Executing erase" << std::endl;
 	erase(lba, size);
 	return true;
@@ -163,8 +163,8 @@ void EraseCommand::erase(int lba, int size) {
 
 bool EraseRangeCommand::execute(const std::vector<std::string>& args)
 {
-	int startLba = std::stoi(args.at(1));
-	int endLba = std::stoi(args.at(2));
+	int startLba = std::stoi(args.at(0));
+	int endLba = std::stoi(args.at(1));
 	std::cout << "Executing erase_range" << std::endl;
 	eraseRange(startLba, endLba);
 	return true;

--- a/TestShell/command.cpp
+++ b/TestShell/command.cpp
@@ -1,9 +1,11 @@
 #include "command.h"
+#include "test_script.h"
 #include <iostream>
+#include "command_parser.h"
 
 bool ReadCommand::execute(const std::vector<std::string>& args)
 {
-	int lba = std::stoi(args.at(1));
+	int lba = std::stoi(args.at(0));
 	std::cout << "Executing read from LBA " << lba << std::endl;
 	read(lba);
     return true;
@@ -28,8 +30,8 @@ void ReadCommand::ssdReadAndPrint(int addr)
 
 bool WriteCommand::execute(const std::vector<std::string>& args)
 {
-	int lba = std::stoi(args.at(1));
-	std::string value = args.at(2);
+	int lba = std::stoi(args.at(0));
+	std::string value = args.at(1);
 	std::cout << "Executing write to LBA " << lba << " with value " << value << std::endl;
 	write(lba, value);
     return true;
@@ -198,4 +200,51 @@ void FlushCommand::flush() {
 	catch (SSDExecutionException& e) {
 		std::cout << "[FLUSH] Fail" << std::endl;
 	}
+}
+
+std::unique_ptr<Command> CommandFactory::createCommand(const std::vector<std::string>& commandVector, SSDInterface* ssd) {
+	if (commandVector.empty()) {
+		return nullptr;
+	}
+
+	std::string opCommand = commandVector.at(0);
+
+	if (opCommand == CommandParser::CMD_EXIT) {
+		return std::make_unique<ExitCommand>();
+	}
+	else if (opCommand == CommandParser::CMD_HELP) {
+		return std::make_unique<HelpCommand>();
+	}
+	else if (opCommand == CommandParser::CMD_WRITE) {
+		return std::make_unique<WriteCommand>(ssd);
+	}
+	else if (opCommand == CommandParser::CMD_READ) {
+		return std::make_unique<ReadCommand>(ssd);
+	}
+	else if (opCommand == CommandParser::CMD_FULLWRITE) {
+		return std::make_unique<FullWriteCommand>(ssd);
+	}
+	else if (opCommand == CommandParser::CMD_FULLREAD) {
+		return std::make_unique<FullReadCommand>(ssd);
+	}
+	else if (opCommand == CommandParser::CMD_ERASE) {
+		//
+	}
+	else if (opCommand == CommandParser::CMD_ERASE_RANGE) {
+		//
+	}
+	else if (opCommand == CommandParser::CMD_FLUSH) {
+		//
+	}
+	else if (opCommand == CommandParser::CMD_SCRIPT1 || opCommand == CommandParser::CMD_SCRIPT1_NAME) {
+		return std::make_unique<ScriptsFullWriteAndReadCompare>(ssd);
+	}
+	else if (opCommand == CommandParser::CMD_SCRIPT2 || opCommand == CommandParser::CMD_SCRIPT2_NAME) {
+		return std::make_unique<ScriptsPartialLBAWrite>(ssd);
+	}
+	else if (opCommand == CommandParser::CMD_SCRIPT3 || opCommand == CommandParser::CMD_SCRIPT3_NAME) {
+		return std::make_unique<ScriptsWriteReadAging>(ssd);
+	}
+
+	return nullptr;
 }

--- a/TestShell/command.h
+++ b/TestShell/command.h
@@ -98,10 +98,5 @@ private:
     SSDInterface* ssd;
 
     void flush();
-};
 
-// command Factory
-class CommandFactory {
-public:
-    static std::unique_ptr<Command> createCommand(const std::vector<std::string>& commandVector, SSDInterface* ssd);
 };

--- a/TestShell/command.h
+++ b/TestShell/command.h
@@ -101,4 +101,7 @@ private:
 };
 
 // command Factory
-
+class CommandFactory {
+public:
+    static std::unique_ptr<Command> createCommand(const std::vector<std::string>& commandVector, SSDInterface* ssd);
+};

--- a/TestShell/command_factory.cpp
+++ b/TestShell/command_factory.cpp
@@ -28,13 +28,13 @@ std::unique_ptr<Command> CommandFactory::createCommand(const std::vector<std::st
 		return std::make_unique<FullReadCommand>(ssd);
 	}
 	else if (opCommand == CommandParser::CMD_ERASE) {
-		//
+		return std::make_unique<EraseCommand>(ssd);
 	}
 	else if (opCommand == CommandParser::CMD_ERASE_RANGE) {
-		//
+		return std::make_unique<EraseRangeCommand>(ssd);
 	}
 	else if (opCommand == CommandParser::CMD_FLUSH) {
-		//
+		return std::make_unique<FlushCommand>(ssd);
 	}
 	else if (opCommand == CommandParser::CMD_SCRIPT1 || opCommand == CommandParser::CMD_SCRIPT1_NAME) {
 		return std::make_unique<ScriptsFullWriteAndReadCompare>(ssd);

--- a/TestShell/command_factory.cpp
+++ b/TestShell/command_factory.cpp
@@ -1,0 +1,50 @@
+#include "command_factory.h"
+#include "command_parser.h"
+#include "test_script.h"
+
+std::unique_ptr<Command> CommandFactory::createCommand(const std::vector<std::string>& commandVector, SSDInterface* ssd) {
+	if (commandVector.empty()) {
+		return nullptr;
+	}
+
+	std::string opCommand = commandVector.at(0);
+
+	if (opCommand == CommandParser::CMD_EXIT) {
+		return std::make_unique<ExitCommand>();
+	}
+	else if (opCommand == CommandParser::CMD_HELP) {
+		return std::make_unique<HelpCommand>();
+	}
+	else if (opCommand == CommandParser::CMD_WRITE) {
+		return std::make_unique<WriteCommand>(ssd);
+	}
+	else if (opCommand == CommandParser::CMD_READ) {
+		return std::make_unique<ReadCommand>(ssd);
+	}
+	else if (opCommand == CommandParser::CMD_FULLWRITE) {
+		return std::make_unique<FullWriteCommand>(ssd);
+	}
+	else if (opCommand == CommandParser::CMD_FULLREAD) {
+		return std::make_unique<FullReadCommand>(ssd);
+	}
+	else if (opCommand == CommandParser::CMD_ERASE) {
+		//
+	}
+	else if (opCommand == CommandParser::CMD_ERASE_RANGE) {
+		//
+	}
+	else if (opCommand == CommandParser::CMD_FLUSH) {
+		//
+	}
+	else if (opCommand == CommandParser::CMD_SCRIPT1 || opCommand == CommandParser::CMD_SCRIPT1_NAME) {
+		return std::make_unique<ScriptsFullWriteAndReadCompare>(ssd);
+	}
+	else if (opCommand == CommandParser::CMD_SCRIPT2 || opCommand == CommandParser::CMD_SCRIPT2_NAME) {
+		return std::make_unique<ScriptsPartialLBAWrite>(ssd);
+	}
+	else if (opCommand == CommandParser::CMD_SCRIPT3 || opCommand == CommandParser::CMD_SCRIPT3_NAME) {
+		return std::make_unique<ScriptsWriteReadAging>(ssd);
+	}
+
+	return nullptr;
+}

--- a/TestShell/command_factory.h
+++ b/TestShell/command_factory.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "command.h"
+
+// command Factory
+class CommandFactory {
+public:
+    static std::unique_ptr<Command> createCommand(const std::vector<std::string>& commandVector, SSDInterface* ssd);
+};

--- a/TestShell/shell_read_test.cpp
+++ b/TestShell/shell_read_test.cpp
@@ -36,7 +36,7 @@ TEST_F(TestShellRead, ReadPassWithMockSSD) {
 	auto oldCoutStreamBuf = std::cout.rdbuf();
 	std::cout.rdbuf(oss.rdbuf());
 
-	vector<string> args = { "read", std::to_string(0)};
+	vector<string> args = { std::to_string(0)};
 	cmd.execute(args);
 	std::cout.rdbuf(oldCoutStreamBuf);
 
@@ -58,7 +58,7 @@ TEST_F(TestShellRead, FullReadPassWithMockSSD) {
 	auto oldCoutStreamBuf = std::cout.rdbuf();
 	std::cout.rdbuf(oss.rdbuf());
 
-	vector<string> args = { "fullread" };
+	vector<string> args = { };
 	cmd.execute(args);
 	std::cout.rdbuf(oldCoutStreamBuf);
 
@@ -116,7 +116,7 @@ TEST_F(TestShellRead, ReadPassWithMockRunExe) {
 	auto oldCoutStreamBuf = std::cout.rdbuf();
 	std::cout.rdbuf(oss.rdbuf());
 
-	vector<string> args = { "read", std::to_string(0)};
+	vector<string> args = { std::to_string(0)};
 	cmd.execute(args);
 	std::cout.rdbuf(oldCoutStreamBuf);
 
@@ -137,7 +137,7 @@ TEST_F(TestShellRead, FullReadPassWithMockRunExe) {
 	auto oldCoutStreamBuf = std::cout.rdbuf();
 	std::cout.rdbuf(oss.rdbuf());
 
-	vector<string> args = { "fullread" };
+	vector<string> args = { };
 	cmd.execute(args);
 	std::cout.rdbuf(oldCoutStreamBuf);
 
@@ -167,7 +167,7 @@ TEST_F(TestShellRead, ReadFailWithMockRunExe) {
 	auto oldCoutStreamBuf = std::cout.rdbuf();
 	std::cout.rdbuf(oss.rdbuf());
 
-	vector<string> args = { "read", std::to_string(0)};
+	vector<string> args = {std::to_string(0)};
 	cmd.execute(args);
 	std::cout.rdbuf(oldCoutStreamBuf);
 
@@ -186,7 +186,7 @@ TEST_F(TestShellRead, FullReadFailWithMockRunExe) {
 	auto oldCoutStreamBuf = std::cout.rdbuf();
 	std::cout.rdbuf(oss.rdbuf());
 
-	vector<string> args = { "fullread" };
+	vector<string> args = {};
 	cmd.execute(args);
 	std::cout.rdbuf(oldCoutStreamBuf);
 

--- a/TestShell/shell_run_script_test.cpp
+++ b/TestShell/shell_run_script_test.cpp
@@ -10,9 +10,13 @@ public:
 
 	void testRun(string argv) {
 		shell.setSSD(new SSDDriver());
+
+		auto oldCoutStreamBuf = std::cout.rdbuf();
 		std::cout.rdbuf(oss.rdbuf());
 
 		shell.runScript(argv);
+
+		std::cout.rdbuf(oldCoutStreamBuf);
 	}
 };
 
@@ -21,8 +25,6 @@ TEST_F(ShellRunScript, NoFile) {
 
 	testRun(argv);
 	
-	auto oldCoutStreamBuf = std::cout.rdbuf();
-	std::cout.rdbuf(oldCoutStreamBuf);
 	EXPECT_EQ("[Error] Invalid File Name.\n", getLastLine(oss.str()));
 }
 
@@ -35,8 +37,6 @@ TEST_F(ShellRunScript, ExistFileButWrongCommand) {
 
 	testRun(argv);
 
-	auto oldCoutStreamBuf = std::cout.rdbuf();
-	std::cout.rdbuf(oldCoutStreamBuf);
 	EXPECT_EQ("read 1   ___   Run ... FAIL\n", getLastLine(oss.str()));
 }
 
@@ -52,7 +52,5 @@ TEST_F(ShellRunScript, ExistFileAndGoodCommand) {
 
 	testRun(argv);
 
-	auto oldCoutStreamBuf = std::cout.rdbuf();
-	std::cout.rdbuf(oldCoutStreamBuf);
 	EXPECT_EQ("2_PartialLBAWrite   ___   Run ... PASS\n", getLastLine(oss.str()));
 }

--- a/TestShell/shell_write_test.cpp
+++ b/TestShell/shell_write_test.cpp
@@ -27,11 +27,11 @@ public:
 		return file.good();
 	}
 	void executeWrite(int lba, string value) {
-		vector<string> args = { "write", std::to_string(lba), value};
+		vector<string> args = { std::to_string(lba), value};
 		writeCmd.execute(args);
 	}
 	void executeFullWrite(string value) {
-		vector<string> args = { "fullwrite", value};
+		vector<string> args = { value};
 		fullWriteCmd.execute(args);
 	}
 protected:

--- a/TestShell/test_shell.cpp
+++ b/TestShell/test_shell.cpp
@@ -21,19 +21,6 @@ bool TestShell::ExecuteCommand(vector<string> commandVector)
         return true;
     }
 
-    if (opCommand == CommandParser::CMD_ERASE) {
-        Command* command = new EraseCommand(ssd);
-        if (!command->execute(commandVector)) return false;
-    }
-    else if (opCommand == CommandParser::CMD_ERASE_RANGE) {
-        Command* command = new EraseRangeCommand(ssd);
-        if (!command->execute(commandVector)) return false;
-    }
-    else if (opCommand == CommandParser::CMD_FLUSH) {
-        Command* command = new FlushCommand(ssd);
-        if (!command->execute(commandVector)) return false;
-    }
-
     return true;
 }
 

--- a/TestShell/test_shell.cpp
+++ b/TestShell/test_shell.cpp
@@ -1,7 +1,6 @@
 ﻿#include "test_shell.h"
 #include "command_parser.h"
 #include "test_script.h"
-//#include "command.h"
 #include "command_factory.h"
 #include <iostream>
 

--- a/TestShell/test_shell.cpp
+++ b/TestShell/test_shell.cpp
@@ -1,8 +1,8 @@
 ﻿#include "test_shell.h"
 #include "command_parser.h"
 #include "test_script.h"
-#include "command.h"
-
+//#include "command.h"
+#include "command_factory.h"
 #include <iostream>
 
 using std::cout;

--- a/TestShell/test_shell.cpp
+++ b/TestShell/test_shell.cpp
@@ -10,31 +10,18 @@ bool TestShell::ExecuteCommand(vector<string> commandVector)
 {
     std::string opCommand = commandVector.at(0);
 
-    if (opCommand == CommandParser::CMD_EXIT) {
-        Command* command = new ExitCommand();
-        if (!command->execute(commandVector)) return false;
+    std::unique_ptr<Command> command = CommandFactory::createCommand(commandVector, ssd);
+
+    if (command) {
+        std::vector<std::string> args(commandVector.begin() + 1, commandVector.end());
+        return command->execute(args);
     }
-    else if (opCommand == CommandParser::CMD_HELP) {
-        Command* command = new HelpCommand();
-        if (!command->execute(commandVector)) return false;
+    else {
+        std::cout << "[Error] Unknown command: " << commandVector.at(0) << std::endl;
+        return true;
     }
-    else if (opCommand == CommandParser::CMD_WRITE) {
-        Command* command = new WriteCommand(ssd);
-        if (!command->execute(commandVector)) return false;
-    }
-    else if (opCommand == CommandParser::CMD_READ) {
-        Command* command = new ReadCommand(ssd);
-        if (!command->execute(commandVector)) return false;
-    }
-    else if (opCommand == CommandParser::CMD_FULLWRITE) {
-        Command* command = new FullWriteCommand(ssd);
-        if (!command->execute(commandVector)) return false;
-    }
-    else if (opCommand == CommandParser::CMD_FULLREAD) {
-        Command* command = new FullReadCommand(ssd);
-        if (!command->execute(commandVector)) return false;
-    }
-    else if (opCommand == CommandParser::CMD_ERASE) {
+
+    if (opCommand == CommandParser::CMD_ERASE) {
         Command* command = new EraseCommand(ssd);
         if (!command->execute(commandVector)) return false;
     }
@@ -45,21 +32,6 @@ bool TestShell::ExecuteCommand(vector<string> commandVector)
     else if (opCommand == CommandParser::CMD_FLUSH) {
         Command* command = new FlushCommand(ssd);
         if (!command->execute(commandVector)) return false;
-    }
-    else if (opCommand == CommandParser::CMD_SCRIPT1 || opCommand == CommandParser::CMD_SCRIPT1_NAME) {
-        Command* command = new ScriptsFullWriteAndReadCompare(ssd);
-        if (!command->execute(commandVector)) return false;
- }
-    else if (opCommand == CommandParser::CMD_SCRIPT2 || opCommand == CommandParser::CMD_SCRIPT2_NAME) {
-        Command* command = new ScriptsPartialLBAWrite(ssd);
-        if (!command->execute(commandVector)) return false;
-    }
-    else if (opCommand == CommandParser::CMD_SCRIPT3 || opCommand == CommandParser::CMD_SCRIPT3_NAME) {
-        Command* command = new ScriptsWriteReadAging(ssd);
-        if (!command->execute(commandVector)) return false;
-    }
-    else {
-        std::cout << "[Error] Unknown command: " << opCommand << std::endl;
     }
 
     return true;

--- a/TestShell/testshell_execute_command_test.cpp
+++ b/TestShell/testshell_execute_command_test.cpp
@@ -1,7 +1,6 @@
-
+#pragma once
 #include "gmock/gmock.h"
-#include "test_shell.h"
-
+#include "mock_ssd.h"
 #include <string>
 
 using namespace testing;
@@ -9,7 +8,7 @@ using namespace std;
 
 //class MockTestShell : public TestShell {
 //public:
-//	MOCK_METHOD(void, read, (int lba));
+//	MOCK_METHOD(void, help, (int lba));
 //	MOCK_METHOD(void, write, (int lba, std::string value));
 //	MOCK_METHOD(void, fullRead, ());
 //	MOCK_METHOD(void, fullWrite, (std::string value));
@@ -17,44 +16,49 @@ using namespace std;
 //private:
 //};
 //
-//class TestShellCommandOperatorFixture : public Test {
-//public:
-//	void SetUp() override {
-//	}
-//	MockTestShell app;
-//};
-//TEST_F(TestShellCommandOperatorFixture, Read) {
-//	vector<string> commandVector = { "read", "3" };
-//
-//	EXPECT_CALL(app, read(_))
-//		.Times(1);
-//
-//	app.ExecuteCommand(commandVector);
-//}
-//TEST_F(TestShellCommandOperatorFixture, Write) {
-//	vector<string> commandVector = { "write", "3", "0xAAAAAAAA"};
-//
-//	EXPECT_CALL(app, write(_, _))
-//		.Times(1);
-//
-//	app.ExecuteCommand(commandVector);
-//}
-//TEST_F(TestShellCommandOperatorFixture, FullRead) {
-//	vector<string> commandVector = { "fullread" };
-//
-//	EXPECT_CALL(app, fullRead)
-//		.Times(1);
-//
-//	app.ExecuteCommand(commandVector);
-//}
-//TEST_F(TestShellCommandOperatorFixture, FullWrite) {
-//	vector<string> commandVector = { "fullwrite", "0xAAAAAAAA"};
-//
-//	EXPECT_CALL(app, fullWrite(_))
-//		.Times(1);
-//
-//	app.ExecuteCommand(commandVector);
-//}
+class TestShellCommandOperatorFixture : public Test {
+public:
+	TestShell app;
+
+	void SetUp() override {
+		app.setSSD(&mockSSD);
+	}
+public:
+	MockSSD mockSSD;
+};
+
+TEST_F(TestShellCommandOperatorFixture, Read) {
+	vector<string> commandVector = { "read", "3" };
+
+	EXPECT_CALL(mockSSD, read(_))
+		.Times(1);
+
+	app.ExecuteCommand(commandVector);
+}
+TEST_F(TestShellCommandOperatorFixture, Write) {
+	vector<string> commandVector = { "write", "3", "0xAAAAAAAA"};
+
+	EXPECT_CALL(mockSSD, write(_, _))
+		.Times(1);
+
+	app.ExecuteCommand(commandVector);
+}
+TEST_F(TestShellCommandOperatorFixture, FullRead) {
+	vector<string> commandVector = { "fullread" };
+
+	EXPECT_CALL(mockSSD, read(_))
+		.Times(100);
+
+	app.ExecuteCommand(commandVector);
+}
+TEST_F(TestShellCommandOperatorFixture, FullWrite) {
+	vector<string> commandVector = { "fullwrite", "0xAAAAAAAA"};
+
+	EXPECT_CALL(mockSSD, write(_, _))
+		.Times(100);
+
+	app.ExecuteCommand(commandVector);
+}
 //TEST_F(TestShellCommandOperatorFixture, Help) {
 //	vector<string> commandVector = { "help" };
 //

--- a/TestShell/testshell_execute_command_test.cpp
+++ b/TestShell/testshell_execute_command_test.cpp
@@ -59,11 +59,27 @@ TEST_F(TestShellCommandOperatorFixture, FullWrite) {
 
 	app.ExecuteCommand(commandVector);
 }
-//TEST_F(TestShellCommandOperatorFixture, Help) {
-//	vector<string> commandVector = { "help" };
-//
-//	EXPECT_CALL(app, help)
-//		.Times(1);
-//
-//	app.ExecuteCommand(commandVector);
-//}
+TEST_F(TestShellCommandOperatorFixture, Erase) {
+	vector<string> commandVector = { "erase", "5", "2"};
+
+	EXPECT_CALL(mockSSD, erase(5, 2))
+		.Times(1);
+
+	app.ExecuteCommand(commandVector);
+}
+TEST_F(TestShellCommandOperatorFixture, EraseRange) {
+	vector<string> commandVector = { "erase_range", "1", "4" };
+
+	EXPECT_CALL(mockSSD, erase(1, 4))
+		.Times(1);
+
+	app.ExecuteCommand(commandVector);
+}
+TEST_F(TestShellCommandOperatorFixture, Flush) {
+	vector<string> commandVector = { "flush" };
+
+	EXPECT_CALL(mockSSD, flush())
+		.Times(1);
+
+	app.ExecuteCommand(commandVector);
+}

--- a/TestShell/testshell_execute_command_test.cpp
+++ b/TestShell/testshell_execute_command_test.cpp
@@ -6,16 +6,6 @@
 using namespace testing;
 using namespace std;
 
-//class MockTestShell : public TestShell {
-//public:
-//	MOCK_METHOD(void, help, (int lba));
-//	MOCK_METHOD(void, write, (int lba, std::string value));
-//	MOCK_METHOD(void, fullRead, ());
-//	MOCK_METHOD(void, fullWrite, (std::string value));
-//	MOCK_METHOD(void, help, ());
-//private:
-//};
-//
 class TestShellCommandOperatorFixture : public Test {
 public:
 	TestShell app;

--- a/TestShell/testshell_execute_command_test.cpp
+++ b/TestShell/testshell_execute_command_test.cpp
@@ -25,6 +25,7 @@ public:
 	}
 public:
 	MockSSD mockSSD;
+	string testData = "0x00012345";
 };
 
 TEST_F(TestShellCommandOperatorFixture, Read) {
@@ -80,6 +81,49 @@ TEST_F(TestShellCommandOperatorFixture, Flush) {
 
 	EXPECT_CALL(mockSSD, flush())
 		.Times(1);
+
+	app.ExecuteCommand(commandVector);
+}
+TEST_F(TestShellCommandOperatorFixture, TestScript1) {
+	vector<string> commandVector = { "1_" };
+
+	EXPECT_CALL(mockSSD, write(_, _))
+		.Times(100);
+	EXPECT_CALL(mockSSD, read(_))
+		.Times(100)
+		.WillRepeatedly(Return(testData));
+
+	app.ExecuteCommand(commandVector);
+}
+TEST_F(TestShellCommandOperatorFixture, TestScript2) {
+	vector<string> commandVector = { "2_" };
+
+	// Write expectations
+	EXPECT_CALL(mockSSD, write(_, _))
+		.WillRepeatedly(Return());
+
+	// Read expectations
+	EXPECT_CALL(mockSSD, read(_))
+		.WillRepeatedly(Return(testData));
+
+	app.ExecuteCommand(commandVector);
+}
+TEST_F(TestShellCommandOperatorFixture, TestScript3) {
+	vector<string> commandVector = { "3_" };
+
+	std::string val0 = "0x00001111";
+	std::string val99 = "0x00009999";
+
+	EXPECT_CALL(mockSSD, write(0, val0))
+		.Times(200);
+	EXPECT_CALL(mockSSD, write(99, val99))
+		.Times(200);
+	EXPECT_CALL(mockSSD, read(0))
+		.Times(200)
+		.WillRepeatedly(Return(val0));
+	EXPECT_CALL(mockSSD, read(99))
+		.Times(200)
+		.WillRepeatedly(Return(val99));
 
 	app.ExecuteCommand(commandVector);
 }


### PR DESCRIPTION
## 📌 PR 제목
- [Refactoring] TestShell에서 command 객체 생성 부를 Factory pattern으로 변경

## 📄 변경 사항
- factory pattern을 적용하여 execute command 부분을 간소화

## 🔍 상세 설명
- command 추가/변경 시 필요한 변경점을 줄이기 위해 Factory pattern을 적용하였습니다.

## ✅ 체크리스트
- [ ] 코드 스타일을 따랐는가?
- [x] 테스트를 작성했는가?
- [x] master branch 리베이스 후 빌드 확인 하였는가?