### PR TITLE
[refactor] modify to execute SSD.exe from TestShell for speed up

### DIFF
--- a/TestShell/ssd_interface.cpp
+++ b/TestShell/ssd_interface.cpp
@@ -1,36 +1,80 @@
 #include "ssd_interface.h"
+#include <windows.h>
+#include <sstream>
+#include <iostream>
+#include <fstream>
 
-void SSDDriver::write(int lba, string value) {
-	string command = "\"ssd W " + std::to_string(lba) + " " + value + " >nul 2>&1\"";
-	if (runExe(command) == false) {
-		throw SSDExecutionException("Execution failed: " + command);
-	}
+bool SSDDriver::runExe(const std::string& command) {
+    STARTUPINFOA si = { sizeof(si) };
+    PROCESS_INFORMATION pi;
+
+    std::istringstream iss(command);
+    std::string exe;
+    iss >> exe;
+
+    std::string args;
+    std::getline(iss, args); // args = " W 3 0x123456"
+
+    std::string fullCommandLine = exe + args;
+
+    char cmdLine[512];
+    strcpy_s(cmdLine, fullCommandLine.c_str());
+
+    BOOL result = CreateProcessA(
+        exe.c_str(),      // execution file e.g. SSD.exe
+        cmdLine,          // total cmd line
+        NULL, NULL,
+        FALSE,
+        0,                // flag like CREATE_NO_WINDOW if needed
+        NULL, NULL,
+        &si, &pi
+    );
+
+    if (!result) {
+        return false;
+    }
+
+    WaitForSingleObject(pi.hProcess, INFINITE);
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+    return true;
 }
 
-string SSDDriver::read(int lba) {
-	string command = "\"ssd R " + std::to_string(lba) + " >nul 2>&1\"";
-	if (runExe(command) == false) {
-		throw std::runtime_error("There is no SSD.exe\n");
-	}
+void SSDDriver::write(int lba, std::string value) {
+    std::string command = "ssd.exe W " + std::to_string(lba) + " " + value;
+    if (!runExe(command)) {
+        throw SSDExecutionException("Execution failed: " + command);
+    }
+}
 
-	string content;
-	std::ifstream file(SSD_READ_RESULT);
-	std::getline(file, content);
-	file.close();
+std::string SSDDriver::read(int lba) {
+    std::string command = "ssd.exe R " + std::to_string(lba);
+    if (!runExe(command)) {
+        throw std::runtime_error("Failed to execute ssd.exe for read()");
+    }
 
-	return content;
+    std::ifstream file(SSD_READ_RESULT);
+    if (!file.is_open()) {
+        throw std::runtime_error("Failed to open result file: " + SSD_READ_RESULT);
+    }
+
+    std::string content;
+    std::getline(file, content);
+    file.close();
+
+    return content;
 }
 
 void SSDDriver::erase(int lba, int size) {
-	string command = "\"ssd E " + std::to_string(lba) + " " + std::to_string(size) + " >nul 2>&1\"";
-	if (runExe(command) == false) {
-		throw SSDExecutionException("Execution failed: " + command);
-	}
+    std::string command = "ssd.exe E " + std::to_string(lba) + " " + std::to_string(size);
+    if (!runExe(command)) {
+        throw SSDExecutionException("Execution failed: " + command);
+    }
 }
 
 void SSDDriver::flush() {
-	string command = "\"ssd F >nul 2>&1\"";
-	if (runExe(command) == false) {
-		throw SSDExecutionException("Execution failed: " + command);
-	}
+    std::string command = "ssd.exe F";
+    if (!runExe(command)) {
+        throw SSDExecutionException("Execution failed: " + command);
+    }
 }

--- a/TestShell/ssd_interface.h
+++ b/TestShell/ssd_interface.h
@@ -2,44 +2,41 @@
 #include <iostream>
 #include <fstream>
 #include "gmock/gmock.h"
+#include <windows.h>
+#include <string>
 
 using std::string;
 
 class SSDInterface {
 public:
-	virtual void write(int lba, string value) = 0;
-	virtual string read(int lba) = 0;
-	virtual void erase(int lba, int size) = 0;
-	virtual void flush() = 0;
+    virtual void write(int lba, string value) = 0;
+    virtual string read(int lba) = 0;
+    virtual void erase(int lba, int size) = 0;
+    virtual void flush() = 0;
 };
 
 class SSDDriver : public SSDInterface {
 public:
-	virtual bool runExe(const string& command) {
-		int isFail = system(command.c_str());
-
-		if (isFail) return false;
-		return true;
-	}
-	void write(int lba, string value) override;
-	string read(int lba) override;
-	void erase(int lba, int size) override;
-	void flush() override;
+    virtual bool runExe(const string& command);
+    void write(int lba, string value) override;
+    string read(int lba) override;
+    void erase(int lba, int size) override;
+    void flush() override;
 
 private:
-	const string SSD_READ_RESULT = "../ssd_output.txt";
+    const string SSD_READ_RESULT = "../ssd_output.txt";
 };
 
 class SSDExecutionException : public std::exception {
 public:
-	explicit SSDExecutionException(const std::string& msg)
-		: message_(msg) {
-	}
+    explicit SSDExecutionException(const std::string& msg)
+        : message_(msg) {
+    }
 
-	const char* what() const noexcept override {
-		return message_.c_str();
-	}
+    const char* what() const noexcept override {
+        return message_.c_str();
+    }
 
 private:
-	std::string message_;
+    std::string message_;
 };


### PR DESCRIPTION
## 📌 PR 제목
- [refactor] modify to execute SSD.exe from TestShell for speed up

## 📄 변경 사항
- ssd_interface에서 SSD.exe 실행 시 기존에는 system() 호출을 사용
- 이를 Windows API의 CreateProcessA() 방식으로 변경하여 테스트 실행 속도 개선

## 🔍 상세 설명
- 기존 방식 (system())은 새로운 셸 인스턴스를 매번 생성하므로, test script (e.g., 3_) 실행에 4분 이상 소요되는 경우 발생
- CreateProcessA()를 사용함으로써 프로세스 생성 오버헤드를 줄이고 테스트 실행 시간을 획기적으로 단축
- SSD.exe 명령은 더이상 셸 리다이렉션 없이 실행되며, 실패 시 명확한 오류 로그를 남김
- 결과적으로 반복되는 테스트 수행의 효율성을 크게 향상시킴   (3_ 수행하는데 기존 4분이상 -> 10초 이내)

## ✅ 체크리스트
- [ ] 코드 스타일을 따랐는가?
- [ ] 테스트를 작성했는가?
- [x] master branch 리베이스 후 빌드 확인 하였는가?