### PR TITLE
[fixup] ssd 기능은 size 10만 받기 때문에 size parse 후 erase 호출하도록 변경

### DIFF
--- a/TestShell/command.cpp
+++ b/TestShell/command.cpp
@@ -163,11 +163,27 @@ void EraseCommand::erase(int lba, int size) {
 			size = 100 - lba;
 		}
 
-		ssd->erase(lba, size);
+		parseSizeAndErase(size, lba);
+
 		std::cout << "[ERASE] Done" << std::endl;
 	}
 	catch (SSDExecutionException& e) {
 		std::cout << "[ERASE] Fail" << std::endl;
+	}
+}
+
+void EraseCommand::parseSizeAndErase(int size, int lba)
+{
+	while (size > 0) {
+		if (size > 10) {
+			ssd->erase(lba, 10);
+			lba = lba + 10;
+			size = size - 10;
+		}
+		else {
+			ssd->erase(lba, size);
+			size = 0;
+		}
 	}
 }
 

--- a/TestShell/command.h
+++ b/TestShell/command.h
@@ -77,6 +77,8 @@ protected:
 
 private:
     SSDInterface* ssd;
+
+    void parseSizeAndErase(int size, int lba);
 };
 
 class EraseRangeCommand : public EraseCommand {


### PR DESCRIPTION
## 📌 PR 제목
- [fixup] ssd 기능은 size 10만 받기 때문에 size parse 후 erase 호출하도록 변경

## 📄 변경 사항
- ssd erase 호출 시 size가 10을 넘지 않도록 하였습니다.

## 🔍 상세 설명
- ssd는 오직 size 10까지만 erase 할 수 있기때문에 test shell에서 이를 parsing 해서 넣어야 합니다.
- 
## ✅ 체크리스트
- [x] 코드 스타일을 따랐는가?
- [ ] 테스트를 작성했는가?
- [x] master branch 리베이스 후 빌드 확인 하였는가?