### PR TITLE
[refactoring] use filesystem as C++17 can be available

### DIFF
--- a/SSD/SSD.vcxproj
+++ b/SSD/SSD.vcxproj
@@ -76,6 +76,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -90,6 +91,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -102,6 +104,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -116,6 +119,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/TestShell/TestShell.vcxproj
+++ b/TestShell/TestShell.vcxproj
@@ -76,6 +76,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -90,6 +91,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -102,6 +104,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -116,6 +119,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/TestShell/file_util.cpp
+++ b/TestShell/file_util.cpp
@@ -1,81 +1,64 @@
 #include "file_util.h"
 #include <fstream>
-#include <sys/stat.h>
-#include <direct.h>
+#include <filesystem>
 
-#define mkdir _mkdir
+namespace fs = std::filesystem;
 
 bool FileUtil::directoryExists(const std::string& path) {
-    struct stat info;
-    if (stat(path.c_str(), &info) != 0) return false;
-    return (info.st_mode & S_IFDIR);
+	return fs::is_directory(path);
 }
 
 bool FileUtil::createDirectory(const std::string& path) {
-    if (directoryExists(path)) return true;
-    return mkdir(path.c_str()) == 0;
+	if (directoryExists(path)) return true;
+	return fs::create_directories(path);
 }
 
 bool FileUtil::fileExists(const std::string& path) {
-    std::ifstream f(path.c_str());
-    return f.good();
+	return fs::is_regular_file(path);
 }
 
 bool FileUtil::writeLine(const std::string& filePath, const std::string& line, bool append) {
-    std::ofstream ofs;
-    if (append)
-        ofs.open(filePath.c_str(), std::ios::app);
-    else
-        ofs.open(filePath.c_str(), std::ios::trunc);
+	std::ofstream ofs(filePath, append ? std::ios::app : std::ios::trunc);
+	if (!ofs) return false;
 
-    if (!ofs.is_open()) return false;
-    ofs << line << std::endl;
-    return ofs.good();
+	ofs << line << '\n';
+	return ofs.good();
 }
 
 bool FileUtil::readLine(const std::string& filePath, std::string& lineOut) {
-    std::ifstream ifs(filePath.c_str());
-    if (!ifs.is_open()) return false;
-    if (!std::getline(ifs, lineOut)) {
-        return false;
-    }
-    return ifs.good();
+	std::ifstream ifs(filePath);
+	return ifs && static_cast<bool>(std::getline(ifs, lineOut));
 }
 
 bool FileUtil::clearFile(const std::string& filePath) {
-    std::ofstream ofs(filePath.c_str(), std::ios::trunc);
-    return ofs.is_open();
+	std::ofstream ofs(filePath, std::ios::trunc);
+	return ofs.is_open();
 }
 
 bool FileUtil::writeAllLines(const std::string& filePath, const std::vector<std::string>& lines, bool append) {
-    std::ofstream ofs;
-    if (append)
-        ofs.open(filePath.c_str(), std::ios::app);
-    else
-        ofs.open(filePath.c_str(), std::ios::trunc);
+	std::ofstream ofs(filePath, append ? std::ios::app : std::ios::trunc);
+	if (!ofs) return false;
 
-    if (!ofs.is_open()) return false;
-
-    for (const auto& line : lines) {
-        ofs << line << std::endl;
-        if (!ofs.good()) return false;
-    }
-    return true;
+	for (const auto& line : lines) {
+		ofs << line << '\n';
+		if (!ofs) return false;
+	}
+	return true;
 }
 
 bool FileUtil::readAllLines(const std::string& filePath, std::vector<std::string>& linesOut) {
-    std::ifstream ifs(filePath.c_str());
-    if (!ifs.is_open()) return false;
+	std::ifstream ifs(filePath);
+	if (!ifs) return false;
 
-    std::string line;
-    while (std::getline(ifs, line)) {
-        linesOut.push_back(line);
-    }
-    return ifs.eof();
+	std::string line;
+	while (std::getline(ifs, line)) {
+		linesOut.push_back(line);
+	}
+	return true;
 }
 
 size_t FileUtil::getFileSize(const std::string& filePath) {
-    std::ifstream ifs(filePath.c_str(), std::ios::binary | std::ios::ate);
-    if (!ifs.is_open()) return 0;
-    return ifs.tellg();
+	std::error_code ec;
+	const auto size = fs::file_size(filePath, ec);
+	return ec ? 0 : static_cast<size_t>(size);
 }

--- a/TestShell/file_util.h
+++ b/TestShell/file_util.h
@@ -5,13 +5,16 @@
 
 class FileUtil {
 public:
-    static bool directoryExists(const std::string& path);
-    static bool createDirectory(const std::string& path);
-    static bool fileExists(const std::string& path);
-    static bool writeLine(const std::string& filePath, const std::string& line, bool append = true);
-    static bool readLine(const std::string& filePath, std::string& lineOut);
-    static bool clearFile(const std::string& filePath);
-    static bool writeAllLines(const std::string& filePath, const std::vector<std::string>& lines, bool append = false);
-    static bool readAllLines(const std::string& filePath, std::vector<std::string>& linesOut);
-    static size_t getFileSize(const std::string& filePath);
+	static bool directoryExists(const std::string& path);
+	static bool createDirectory(const std::string& path);
+	static bool fileExists(const std::string& path);
+
+	static bool writeLine(const std::string& filePath, const std::string& line, bool append = true);
+	static bool readLine(const std::string& filePath, std::string& lineOut);
+	static bool clearFile(const std::string& filePath);
+
+	static bool writeAllLines(const std::string& filePath, const std::vector<std::string>& lines, bool append = false);
+	static bool readAllLines(const std::string& filePath, std::vector<std::string>& linesOut);
+
+	static size_t getFileSize(const std::string& filePath);
 };


### PR DESCRIPTION
## 📌 PR 제목
- [refactoring] use filesystem as C++17 can be available

## 📄 변경 사항
- c++17로 팀원 개발 환경을 맞추면서 file_util이 std::filesystem 을 사용하도록 변경하였습니다.

## 🔍 상세 설명
- 직관적이고 이해하기 쉬운 함수를 사용함으로써 가독성을 높이는 refactoring 작업이 될 수 있을 것 같습니다.

## ✅ 체크리스트
- [x] 코드 스타일을 따랐는가?
- [ ] 테스트를 작성했는가?
- [x] master branch 리베이스 후 빌드 확인 하였는가?