### PR TITLE
SSD flush

### DIFF
--- a/SSD/command.cpp
+++ b/SSD/command.cpp
@@ -137,9 +137,7 @@ EraseCommand::getSize() const
 void
 FlushCommand::run(string& result)
 {
-	/*
 	CommandBuffer::getInstance().flushBuffer();
-	*/
 }
 
 void

--- a/SSD/command.cpp
+++ b/SSD/command.cpp
@@ -106,3 +106,23 @@ EraseCommand::getSize() const
 {
 	return size;
 }
+
+// FlushCommand
+void
+FlushCommand::run(string& result)
+{
+	/*
+	CommandBuffer::getInstance().flushBuffer();
+	*/
+}
+
+void
+FlushCommand::execute(string& result)
+{
+}
+
+CmdType
+FlushCommand::getCmdType() const
+{
+	return CmdType::FLUSH;
+}

--- a/SSD/command.h
+++ b/SSD/command.h
@@ -9,10 +9,13 @@
 
 using std::string;
 
+class CommandBuffer;
+
 enum class CmdType {
 	READ = 0,
 	WRITE,
 	ERASE,
+	FLUSH
 };
 
 // ICommand (abstract class)
@@ -52,8 +55,6 @@ public:
 	void run(string& result) override;
 	void execute(string& result) override;
 	CmdType getCmdType() const override;
-
-	std::vector<std::shared_ptr<ICommand>> buffers;
 };
 
 // WriteCommand
@@ -86,4 +87,15 @@ public:
 
 private:
     int size;
+};
+
+// FlushCommand
+class FlushCommand : public BaseCommand
+{
+public:
+	using BaseCommand::BaseCommand;
+
+	void run(string& result) override;
+	void execute(string& result) override;
+	CmdType getCmdType() const override;
 };

--- a/SSD/command.h
+++ b/SSD/command.h
@@ -21,7 +21,7 @@ public:
 		ERASE = 2
 	};
 
-	BaseCommand(int lba);
+	BaseCommand(int lba = -1);
 	int getLBA() const;
 };
 

--- a/SSD/command_buffer.cpp
+++ b/SSD/command_buffer.cpp
@@ -33,13 +33,28 @@ CommandBuffer::getBuffer() const
 	return buffer;
 }
 
-int
+void
 CommandBuffer::addCommand(std::shared_ptr<ICommand> command)
 {
-	buffer.push_back(command);
-	optimizeBuffer();
+	int bufSize = buffer.size();
 
-	return buffer.size();
+	if (bufSize == 0) {
+		addCommand(command);
+	}
+	else if (bufSize == CommandBuffer::BUFFER_MAX) {
+		flushBuffer();
+		addCommand(command);;
+	}
+	else {
+		addCommand(command);
+		optimizeBuffer();
+	}
+}
+
+void
+CommandBuffer::clearBuffer()
+{
+	buffer.clear();
 }
 
 void
@@ -53,7 +68,13 @@ CommandBuffer::flushBuffer()
 	}
 
 	NandData::getInstance().updateToFile();
-	buffer.clear();
+	clearBuffer();
+}
+
+void
+CommandBuffer::addCommandToBuffer(std::shared_ptr<ICommand> command)
+{
+	buffer.push_back(command);
 }
 
 bool
@@ -193,7 +214,7 @@ CommandBuffer::updateToDirectory()
 		}
 	}
 
-	for (int i = buffer.size()+1; i <= BUFFER_MAX; ++i) {
+	for (int i = buffer.size() + 1; i <= BUFFER_MAX; ++i) {
 		string filePath = bufferDirPath + "/" + std::to_string(i) + "_" + EMPTY;
 
 		// create file

--- a/SSD/command_buffer.cpp
+++ b/SSD/command_buffer.cpp
@@ -45,14 +45,14 @@ CommandBuffer::addCommand(std::shared_ptr<ICommand> command)
 	int bufSize = buffer.size();
 
 	if (bufSize == 0) {
-		addCommand(command);
+		addCommandToBuffer(command);
 	}
 	else if (bufSize == CommandBuffer::BUFFER_MAX) {
 		flushBuffer();
-		addCommand(command);;
+		addCommandToBuffer(command);;
 	}
 	else {
-		addCommand(command);
+		addCommandToBuffer(command);
 		optimizeBuffer();
 	}
 }

--- a/SSD/command_buffer.h
+++ b/SSD/command_buffer.h
@@ -18,8 +18,10 @@ public:
 
 	int getBufferSize() const;
 	const vector<std::shared_ptr<ICommand>>& getBuffer() const;
-	int addCommand(std::shared_ptr<ICommand> command);
+	
+	void addCommand(std::shared_ptr<ICommand> command);
 
+	void clearBuffer();
 	void flushBuffer();
 	bool optimizeBuffer();
 
@@ -27,6 +29,8 @@ public:
 	static constexpr const char* EMPTY = "empty";
 
 private:
+	void addCommandToBuffer(std::shared_ptr<ICommand> command);
+
 	void initDirectory();
 	void updateFromDirectory();
 

--- a/SSD/command_builder_test.cpp
+++ b/SSD/command_builder_test.cpp
@@ -13,6 +13,7 @@ public:
 	const string CMD_READ = "R";
 	const string CMD_WRITE = "W";
 	const string CMD_ERASE = "E";
+	const string CMD_FLUSH = "F";
 	const string CMD_INVALID = "D";
 
 	const string VALID_LBA = "3";
@@ -65,6 +66,9 @@ TEST_F(SSDCommandParserTestFixture, InvalidParameterCount2)
 	EXPECT_FALSE(builder.isValidCommand());
 
 	builder.setCommandVector({ CMD_ERASE, VALID_LBA });
+	EXPECT_FALSE(builder.isValidCommand());
+
+	builder.setCommandVector({ CMD_FLUSH, VALID_LBA });
 	EXPECT_FALSE(builder.isValidCommand());
 }
 

--- a/SSD/command_interface.h
+++ b/SSD/command_interface.h
@@ -10,6 +10,7 @@ enum class CmdType {
 	READ = 0,
 	WRITE,
 	ERASE,
+	FLUSH
 };
 
 // ICommand (abstract class)

--- a/SSD/nand_data.cpp
+++ b/SSD/nand_data.cpp
@@ -81,12 +81,6 @@ NandData::updateToFile()
 	return ret;
 }
 
-FileInterface&
-NandData::getNandFile() 
-{
-	return file;
-}
-
 NandData::NandData(const string& filePath)
 	: file(filePath)
 {

--- a/SSD/nand_data.h
+++ b/SSD/nand_data.h
@@ -25,9 +25,6 @@ public:
     //bool updateFromBuffer()
     bool updateToFile();
 
-    // for unit test
-    FileInterface& getNandFile();
-
 private:
     NandData(const string& filePath);
     NandData(const NandData&) = delete;

--- a/SSD/ssd.cpp
+++ b/SSD/ssd.cpp
@@ -19,26 +19,28 @@ SSD::run(vector<string> commandVector)
 		builder = std::make_shared<SSDCommandBuilder>();
 	}
 
-	cmdBuf.Init();
 	string result("");
 
 	// create command (validity check included)
 	auto cmd = builder->createCommand(commandVector);
 	if (cmd == nullptr) {
-		result = "ERROR";
-	}
-	else {
-		auto type = cmd->getCmdType();
-		//if (type == CmdType::READ || type == CmdType::FLUSH
-		//{
-		cmd->run(result);
-		//}
-		//else if(type==CmdType::WRITE || type ==CmdType::ERASE {
-			//cmdBuf.addCommand(cmd);
-		//}
+		updateOutputFile("ERROR");
+		return;
 	}
 
+	cmdBuf.Init();
+
+	auto type = cmd->getCmdType();
+	//if (type == CmdType::READ || type == CmdType::FLUSH
+	//{
+	cmd->run(result);
+	//}
+	//else if(type==CmdType::WRITE || type ==CmdType::ERASE {
+		//cmdBuf.addCommand(cmd);
+	//}
+
 	cmdBuf.updateToDirectory();
+
 	if (!result.empty()) {
 		updateOutputFile(result);
 	}

--- a/SSD/ssd.cpp
+++ b/SSD/ssd.cpp
@@ -20,33 +20,31 @@ SSD::run(vector<string> commandVector)
 	}
 
 	cmdBuf.Init();
-
-	// parse command
-	auto cmd = builder->createCommand(commandVector);
-	if (cmd == nullptr) {
-		updateOutputFile("ERROR");
-		return;
-	}
-
 	string result("");
 
-	auto type = cmd->getCmdType();
-	//if (type == CmdType::READ || type == CmdType::FLUSH
-	//{
-	cmd->run(result);
-	//}
-	//else if(type==CmdType::WRITE || type ==CmdType::ERASE {
-		//cmdBuf.addCommand(cmd);
-	//}
+	// create command (validity check included)
+	auto cmd = builder->createCommand(commandVector);
+	if (cmd == nullptr) {
+		result = "ERROR";
+	}
+	else {
+		auto type = cmd->getCmdType();
+		//if (type == CmdType::READ || type == CmdType::FLUSH
+		//{
+		cmd->run(result);
+		//}
+		//else if(type==CmdType::WRITE || type ==CmdType::ERASE {
+			//cmdBuf.addCommand(cmd);
+		//}
+	}
 
 	cmdBuf.updateToDirectory();
-
 	if (!result.empty()) {
 		updateOutputFile(result);
 	}
 }
 
-bool 
+bool
 SSD::updateOutputFile(const string& result)
 {
 	outputFile.fileClear();
@@ -82,7 +80,7 @@ SSD::setBuilder(std::shared_ptr<SSDCommandBuilder> builder)
 	this->builder = builder;
 }
 
-NandData& 
+NandData&
 SSD::getStorage()
 {
 	return storage;

--- a/SSD/ssd.cpp
+++ b/SSD/ssd.cpp
@@ -30,23 +30,13 @@ SSD::run(vector<string> commandVector)
 
 	string result("");
 
-	//if (cmd->getCmdType() == CmdType::READ) {
+	auto type = cmd->getCmdType();
+	//if (type == CmdType::READ || type == CmdType::FLUSH
+	//{
 	cmd->run(result);
 	//}
-	//else {
-		//int bufSize = cmdBuf.getBufferSize();
-
-		//if (bufSize == 0) {
-		//	cmdBuf.addCommand(cmd);
-		//}
-		//else if (bufSize == CommandBuffer::BUFFER_MAX) {
-		//	cmdBuf.flushBuffer();
-		//	cmdBuf.addCommand(cmd);
-		//}
-		//else {
-		//	cmdBuf.addCommand(cmd);
-		//	cmdBuf.optimizeBuffer();
-		//}
+	//else if(type==CmdType::WRITE || type ==CmdType::ERASE {
+		//cmdBuf.addCommand(cmd);
 	//}
 
 	cmdBuf.updateToDirectory();

--- a/SSD/ssd.cpp
+++ b/SSD/ssd.cpp
@@ -87,9 +87,3 @@ SSD::getStorage()
 {
 	return storage;
 }
-
-FileInterface&
-SSD::getOutputFile() 
-{
-	return outputFile;
-}

--- a/SSD/ssd.h
+++ b/SSD/ssd.h
@@ -22,7 +22,6 @@ public:
 	void writeData(int lba, const string& value);
 	void clearData();
 	void setBuilder(std::shared_ptr<SSDCommandBuilder> builder);
-	FileInterface& getOutputFile();
 	NandData& getStorage();
 
 private:

--- a/SSD/ssd_command_builder.cpp
+++ b/SSD/ssd_command_builder.cpp
@@ -113,7 +113,7 @@ SSDCommandBuilder::createCommand(vector<string> inputCommandVector)
 		return std::make_shared<EraseCommand>(lba, size);
 	}
 	else if (opCommand == CMD_FLUSH) {
-		return std::make_shared<FlushCommand>(-1);	// put garbage value to lba
+		return std::make_shared<FlushCommand>();
 	}
 	else {
 		return nullptr;

--- a/SSD/ssd_command_builder.cpp
+++ b/SSD/ssd_command_builder.cpp
@@ -1,7 +1,6 @@
 #include "ssd_command_builder.h"
 
 #include <sstream>
-#include <iostream>
 #include <regex>
 
 using std::istringstream;
@@ -23,15 +22,23 @@ SSDCommandBuilder::isValidCommand() const
 {
 	try {
 		// check parameter count
-		if (commandVector.size() < MAX_ARG_LENGTH - 1
+		if (commandVector.size() < MAX_ARG_LENGTH - 2
 			|| commandVector.size() > MAX_ARG_LENGTH) {
 			return false;
 		}
 
 		// check operation command
 		string opCommand = commandVector.at(OP);
-		if (opCommand != CMD_READ && opCommand != CMD_WRITE && opCommand != CMD_ERASE) {
+		if (!isValidOp(opCommand)) {
 			return false;
+		}
+
+		// for flush, just check parameter count and return
+		if (opCommand == CMD_FLUSH) {
+			if (commandVector.size() != MAX_ARG_LENGTH - 2) {
+				return false;
+			}
+			return true;
 		}
 
 		// check parameter count for each operation case
@@ -105,9 +112,25 @@ SSDCommandBuilder::createCommand(vector<string> inputCommandVector)
 		int size = std::stoi(commandVector.at(SIZE));
 		return std::make_shared<EraseCommand>(lba, size);
 	}
+	else if (opCommand == CMD_FLUSH) {
+		return std::make_shared<FlushCommand>(-1);	// put garbage value to lba
+	}
 	else {
 		return nullptr;
 	}
+}
+
+bool
+SSDCommandBuilder::isValidOp(const string& opStr) const
+{
+	if (opStr == CMD_READ 
+		|| opStr == CMD_WRITE 
+		|| opStr == CMD_ERASE
+		|| opStr == CMD_FLUSH ) {
+		return true;
+	}
+
+	return false;
 }
 
 bool

--- a/SSD/ssd_command_builder.h
+++ b/SSD/ssd_command_builder.h
@@ -34,8 +34,10 @@ public:
 	static constexpr const char* CMD_READ = "R";
 	static constexpr const char* CMD_WRITE = "W";
 	static constexpr const char* CMD_ERASE = "E";
+	static constexpr const char* CMD_FLUSH = "F";
 
 private:
+	bool isValidOp(const string& opStr) const;
 	bool isValidValue(const string& valueStr) const;
 	bool isValidLBA(int lba, int size = 0) const;
 	bool isValidSize(int size) const;

--- a/SSD/ssd_test.cpp
+++ b/SSD/ssd_test.cpp
@@ -37,8 +37,9 @@ public:
 	std::shared_ptr<MockBuilder> mockBuilder;
 
 	SSD app;
-	FileInterface& nandFile = app.getStorage().getNandFile();
-	FileInterface& outputFile = app.getOutputFile();
+
+	FileInterface nandFile{ "../ssd_nand.txt" };
+	FileInterface outputFile{ "../ssd_output.txt" };
 
 	void processMockBuilderFunctions()
 	{
@@ -48,7 +49,7 @@ public:
 	}
 };
 
-TEST_F(SSDTestFixture, RunExecutesCommand) {
+TEST_F(SSDTestFixture, RunCommandTest1) {
 	processMockBuilderFunctions();
 
 	std::vector<std::string> input = { "R", "0" };
@@ -56,6 +57,7 @@ TEST_F(SSDTestFixture, RunExecutesCommand) {
 	EXPECT_CALL(*mockBuilder, createCommand(input))
 		.WillOnce(Return(mockCmd));
 
+	// if READ or FLUSH, directly call run
 	EXPECT_CALL(*mockCmd, getCmdType)
 		.WillOnce(Return(CmdType::READ));
 		
@@ -65,43 +67,56 @@ TEST_F(SSDTestFixture, RunExecutesCommand) {
 	app.run(input);
 }
 
+TEST_F(SSDTestFixture, RunCommandTest2) {
+	processMockBuilderFunctions();
+
+	std::vector<std::string> input = { "W", "0", "0x00001111"};
+
+	EXPECT_CALL(*mockBuilder, createCommand(input))
+		.WillOnce(Return(mockCmd));
+
+	// if WRITE or ERASE, go to buffer
+	EXPECT_CALL(*mockCmd, getCmdType)
+		.WillOnce(Return(CmdType::WRITE));
+		
+	EXPECT_CALL(*mockCmd, run)
+		.Times(0);
+
+	app.run(input);
+}
+
 TEST_F(SSDTestFixture, GetInvalidCommandTest) {
 	processMockBuilderFunctions();
+
+	std::vector<std::string> input = { "R", "0", "0x00000000" };
 
 	EXPECT_CALL(*mockBuilder, isValidCommand)
 		.WillRepeatedly(Return(false));
 
-	EXPECT_CALL(*mockBuilder, createCommand)
-		.Times(1);
-
-	EXPECT_CALL(*mockCmd, execute)
-		.Times(0);
-
-	app.run(vector<string>{"R", "0", "0x00000000"});
-}
-
-// cannot run GetCommandTest anymore
-TEST_F(SSDTestFixture, DISABLED_GetCommandTest) {
-	vector<string> input = { "R", "0" };
-	EXPECT_CALL(*mockBuilder, getCommandVector())
-		.WillRepeatedly(Return(input));
+	EXPECT_CALL(*mockBuilder, createCommand(input))
+		.WillOnce(Return(nullptr));
 
 	app.run(input);
 
-	//EXPECT_EQ("R", app.parsedCommand.at(0));
-	//EXPECT_EQ("0", app.parsedCommand.at(1));
-}
-
-// cannot run ReadTest anymore
-TEST_F(SSDTestFixture, DISABLED_ReadTest) {
-	processMockBuilderFunctions();
-
-	vector<string> input = { "R", "0" };
-	app.run(input);
-
-	FileInterface nandFile = { "../ssd_nand.txt" };
 	string expected;
+	outputFile.fileOpen();
+	outputFile.fileReadOneline(expected);
+	outputFile.fileClose();
 
+	EXPECT_EQ(expected, "ERROR");
+}
+
+TEST_F(SSDTestFixture, ReadTest) {
+	app.run({ "R", "0" });
+	
+	// actual
+	string actual;
+	outputFile.fileOpen();
+	outputFile.fileReadOneline(actual);
+	outputFile.fileClose();
+
+	// expected
+	string expected;
 	nandFile.fileOpen();
 	if (nandFile.checkSize() >= 12)
 		nandFile.fileReadOneline(expected);
@@ -109,24 +124,39 @@ TEST_F(SSDTestFixture, DISABLED_ReadTest) {
 		expected = "0x00000000";
 	nandFile.fileClose();
 
-	EXPECT_EQ(expected, app.getData(0));
+	// storage
+	string storageData = app.getData(0);
+
+	EXPECT_EQ(expected, storageData);
+	EXPECT_EQ(actual, storageData);
 }
 
 // cannot run WriteText anymore
-TEST_F(SSDTestFixture, DISABLED_WriteText) {
-	processMockBuilderFunctions();
-
+TEST_F(SSDTestFixture, WriteText) {
 	vector<string> input = { "W", "0", "0x11112222" };
-	EXPECT_CALL(*mockBuilder, getCommandVector())
-		.WillRepeatedly(Return(input));
 
 	app.run(input);
-	EXPECT_EQ("0x11112222", app.getData(0));
+
+	// storage
+	string storageData = app.getData(0);
+
+	// expected
+	string actual;
+	nandFile.fileOpen();
+	if (nandFile.checkSize() >= 12)
+		nandFile.fileReadOneline(actual);
+	else
+		actual = "0x00000000";
+	nandFile.fileClose();
+
+	EXPECT_EQ("0x11112222", actual);
+	EXPECT_EQ("0x11112222", storageData);
 
 	app.clearData();
 	EXPECT_EQ("0x00000000", app.getData(0));
 }
 
+/*
 TEST_F(SSDTestFixture, TC_FULL_WRITE) {
 	string str[100];
 	char buffer[16];
@@ -176,7 +206,7 @@ TEST_F(SSDTestFixture, TC_WRITE_OUTPUT) {
 TEST_F(SSDTestFixture, TC_RUN_WRITE) {
 	app.run({ "W", "0", "0x11112222" });
 
-	FileInterface nandFile = { "../ssd_nand.txt" };
+	//FileInterface nandFile = { "../ssd_nand.txt" };
 
 	string actual;
 	nandFile.fileOpen();
@@ -189,14 +219,14 @@ TEST_F(SSDTestFixture, TC_RUN_WRITE) {
 TEST_F(SSDTestFixture, TC_RUN_READ) {
 	app.run({ "R", "0" });
 
-	FileInterface nandFile = { "../ssd_nand.txt" };
+	//FileInterface nandFile = { "../ssd_nand.txt" };
 
 	string expected;
 	nandFile.fileOpen();
 	nandFile.fileReadOneline(expected);
 	nandFile.fileClose();
 
-	FileInterface outputFile = { "../ssd_output.txt" };
+	//FileInterface outputFile = { "../ssd_output.txt" };
 
 	string actual;
 	outputFile.fileOpen();
@@ -226,3 +256,4 @@ TEST_F(SSDTestFixture, TC_RUN_ERASE) {
 	EXPECT_EQ(app.getData(9), "0x00000000");
 	EXPECT_EQ(app.getData(10), str[10]);
 }
+*/

--- a/SSD/ssd_test.cpp
+++ b/SSD/ssd_test.cpp
@@ -156,7 +156,6 @@ TEST_F(SSDTestFixture, WriteText) {
 	EXPECT_EQ("0x00000000", app.getData(0));
 }
 
-/*
 TEST_F(SSDTestFixture, TC_FULL_WRITE) {
 	string str[100];
 	char buffer[16];
@@ -256,4 +255,4 @@ TEST_F(SSDTestFixture, TC_RUN_ERASE) {
 	EXPECT_EQ(app.getData(9), "0x00000000");
 	EXPECT_EQ(app.getData(10), str[10]);
 }
-*/
+

--- a/SSD/ssd_test.cpp
+++ b/SSD/ssd_test.cpp
@@ -186,12 +186,13 @@ TEST_F(SSDTestFixture, TC_FULL_WRITE_READ) {
 	app.run({ "R", "0" });
 
 	for (int i = 0; i < 100; i++) {
-		if (app.getData(i) != str[i]) {
-			ret = false;
-			break;
-		}
+		EXPECT_EQ(app.getData(i), str[i]);
+		//if (app.getData(i) != str[i]) {
+		//	ret = false;
+		//	break;
+		//}
 	}
-	EXPECT_TRUE(ret);
+	//EXPECT_TRUE(ret);
 }
 
 TEST_F(SSDTestFixture, TC_WRITE_OUTPUT) {
@@ -202,40 +203,7 @@ TEST_F(SSDTestFixture, TC_WRITE_OUTPUT) {
 	EXPECT_EQ(12, outputFile.checkSize());
 }
 
-TEST_F(SSDTestFixture, TC_RUN_WRITE) {
-	app.run({ "W", "0", "0x11112222" });
-
-	//FileInterface nandFile = { "../ssd_nand.txt" };
-
-	string actual;
-	nandFile.fileOpen();
-	nandFile.fileReadOneline(actual);
-	nandFile.fileClose();
-
-	EXPECT_EQ(actual, "0x11112222");
-}
-
-TEST_F(SSDTestFixture, TC_RUN_READ) {
-	app.run({ "R", "0" });
-
-	//FileInterface nandFile = { "../ssd_nand.txt" };
-
-	string expected;
-	nandFile.fileOpen();
-	nandFile.fileReadOneline(expected);
-	nandFile.fileClose();
-
-	//FileInterface outputFile = { "../ssd_output.txt" };
-
-	string actual;
-	outputFile.fileOpen();
-	outputFile.fileReadOneline(actual);
-	outputFile.fileClose();
-
-	EXPECT_EQ(expected, actual);
-}
-
-TEST_F(SSDTestFixture, TC_RUN_ERASE) {
+TEST_F(SSDTestFixture, TC_ERASE) {
 	string str[100];
 	char buffer[16];
 	char ret = true;
@@ -248,11 +216,9 @@ TEST_F(SSDTestFixture, TC_RUN_ERASE) {
 
 	EXPECT_EQ(1200, nandFile.checkSize());
 
-	// to update storage from nand file
 	app.run({ "E", "0", "10" });
 
 	app.run({ "R", "0" });
 	EXPECT_EQ(app.getData(9), "0x00000000");
 	EXPECT_EQ(app.getData(10), str[10]);
 }
-


### PR DESCRIPTION
## 📌 PR 제목
- [Feature] SSD Flush 구현

## 📄 변경 사항
- ICommand를 상속받는 FlushCommand 구현
- CommandBuffer::addCommand 구현

## 🔍 상세 설명
- FlushCommand
    - Read/Write/Erase 에서 공통으로 lba를 가지고 있어서, 기존에는 BaseCommand에 lba를 멤버로 뒀으나 FlushCommand는 lba 필요 없음
    - lba를 멤버에서 빼는 것보다 FlushCommand 생성 시 유효하지 않은 lba(-1) 값을 넣는 게 더 효율적이라고 판단
- CommandBuffer::addCommand
    - buffer size에 따라 다르게 동작하도록 하는 메서드 SSD::run에서 따로 추출

## ✅ 체크리스트
- [x] 코드 스타일을 따랐는가?
- [ ] 테스트를 작성했는가?
- [x] master branch 리베이스 후 빌드 확인 하였는가?