### PR TITLE
[bugfix] erase range도 size를 10단위로 잘라 erase 호출할 수 있도록 수정

### DIFF
--- a/TestShell/command.cpp
+++ b/TestShell/command.cpp
@@ -176,7 +176,7 @@ void EraseCommand::erase(int lba, int size) {
 			size = 100 - lba;
 		}
 
-		parseSizeAndErase(size, lba);
+		parseSizeAndErase(lba, size);
 		PRINT_LOG("[ERASE] Done");
 		std::cout << "[ERASE] Done" << std::endl;
 	}
@@ -186,7 +186,7 @@ void EraseCommand::erase(int lba, int size) {
 	}
 }
 
-void EraseCommand::parseSizeAndErase(int size, int lba)
+void EraseCommand::parseSizeAndErase(int lba, int size)
 {
 	while (size > 0) {
 		if (size > 10) {
@@ -215,7 +215,7 @@ void EraseRangeCommand::eraseRange(int startLba, int endLba) {
 	if (startLba > endLba)
 		std::swap(startLba, endLba);
 	try {
-		erase(startLba, endLba - startLba + 1);
+		parseSizeAndErase(startLba, endLba - startLba + 1);
 		PRINT_LOG("[ERASE RANGE] Done");
 		std::cout << "[ERASE RANGE] Done" << std::endl;
 	}

--- a/TestShell/command.h
+++ b/TestShell/command.h
@@ -74,11 +74,10 @@ public:
 
 protected:
     void erase(int lba, int size);
+    void parseSizeAndErase(int lba, int size);
 
 private:
     SSDInterface* ssd;
-
-    void parseSizeAndErase(int size, int lba);
 };
 
 class EraseRangeCommand : public EraseCommand {

--- a/TestShell/ssd_interface.cpp
+++ b/TestShell/ssd_interface.cpp
@@ -58,7 +58,7 @@ string SSDDriver::read(int lba) {
 	string command = "ssd.exe R " + std::to_string(lba);
 	PRINT_LOG("send to SSD \"%s\"", command.c_str());
 	if (!runExe(command)) {
-		throw std::runtime_error("Failed to execute ssd.exe for read()");
+		throw std::runtime_error("Failed to execute ssd.exe for read()\n");
 	}
 
 	string content;


### PR DESCRIPTION
## 📌 PR 제목
- [bugfix] erase range도 size를 10단위로 잘라 erase 호출할 수 있도록 수정

## 📄 변경 사항
- erase range에서 erase가 아닌 parseSizeAndErase을 불러 10단위로 잘라 erase 할 수 있도록 합니다.

## 🔍 상세 설명
- 기본 동작 구현에 꼭 필요합니다.

## ✅ 체크리스트
- [ ] 코드 스타일을 따랐는가?
- [ ] 테스트를 작성했는가?
- [ ] master branch 리베이스 후 빌드 확인 하였는가?