### PR TITLE
[bugfix] for first read from ssd_nand.txt

### DIFF
--- a/SSD/nand_data.cpp
+++ b/SSD/nand_data.cpp
@@ -43,6 +43,8 @@ NandData::updateFromFile()
 	file.fileOpen();
 
 	if (file.checkSize() != 1200) {
+		clear();
+		file.fileClose();
 		return false;
 	}
 


### PR DESCRIPTION
## 📌 PR 제목
- [변경 유형] 최초 수행시 nand data를 설정하지 않고 updateFromFile() 이 return 되는 현상 개선

## 📄 변경 사항
- file size가 1200이 아닐 경우 data clear

## 🔍 상세 설명
- 초 수행시 nand data를 설정하지 않고 updateFromFile() 이 return 되어 file size가 0x1200이 아닐 경우 data clear하도록 수정

## ✅ 체크리스트
- [x] 코드 스타일을 따랐는가?
- [ ] 테스트를 작성했는가?
- [x] master branch 리베이스 후 빌드 확인 하였는가?