### PR TITLE
[refactoring] Merge MockSSD & MockSSDDriver

### DIFF
--- a/TestShell/TestShell.vcxproj.filters
+++ b/TestShell/TestShell.vcxproj.filters
@@ -101,9 +101,6 @@
     <ClInclude Include="test_script.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
-    <ClInclude Include="mock_ssd.h">
-      <Filter>헤더 파일</Filter>
-    </ClInclude>
     <ClInclude Include="file_util.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
@@ -115,6 +112,9 @@
     </ClInclude>
     <ClInclude Include="command_factory.h">
       <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="mock_ssd.h">
+      <Filter>테스트 파일</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/TestShell/mock_ssd.h
+++ b/TestShell/mock_ssd.h
@@ -1,15 +1,11 @@
 #pragma once
 #include "test_shell.h"
 
-class MockSSD : public SSDInterface {
+class MockSSDDriver : public SSDInterface {
 public:
 	MOCK_METHOD(void, write, (int lba, string value), (override));
 	MOCK_METHOD(string, read, (int lba), (override));
 	MOCK_METHOD(void, erase, (int lba, int size), (override));
 	MOCK_METHOD(void, flush, (), (override));
-};
-
-class MockSSDDriver : public SSDDriver {
-public:
-	MOCK_METHOD(bool, runExe, (const string& command), (override));
+	MOCK_METHOD(bool, runExe, (const string& command), ());
 };

--- a/TestShell/shell_read_test.cpp
+++ b/TestShell/shell_read_test.cpp
@@ -6,8 +6,7 @@ using namespace testing;
 
 class TestShellRead : public Test, public HandleConsoleOutputFixture {
 public:
-	MockSSD mockSSD;
-	MockSSDDriver SSDwithMockRunExe;
+	MockSSDDriver mockSSD;
 	TestShell shell;
 
 	const string HEADER = "[Read] LBA ";
@@ -78,25 +77,21 @@ TEST_F(TestShellRead, FullReadPassWithMockSSD) {
 }
 
 
-TEST(SSDDriverRead, ReadPassWithMockRunExe) {
-	MockSSDDriver SSDwithMockRunExe;
-
-	EXPECT_CALL(SSDwithMockRunExe, runExe)
+TEST_F(TestShellRead, ReadPassWithMockRunExe) {
+	EXPECT_CALL(mockSSD, runExe)
 		.Times(1)
 		.WillRepeatedly(Return(true));
 
-	EXPECT_EQ("0xAAAAAAAA", SSDwithMockRunExe.read(0));
+	EXPECT_EQ("0xAAAAAAAA", mockSSD.read(0));
 }
 
-TEST(SSDDriverRead, ReadFailWithMockRunExe) {
-	MockSSDDriver SSDwithMockRunExe;
-
-	EXPECT_CALL(SSDwithMockRunExe, runExe)
+TEST(TestShellRead, ReadFailWithMockRunExe) {
+	EXPECT_CALL(mockSSD, runExe)
 		.Times(1)
 		.WillRepeatedly(Return(false));
 
 	try {
-		SSDwithMockRunExe.read(0);
+		mockSSD.read(0);
 		FAIL();
 	}
 	catch (std::runtime_error e) {
@@ -106,11 +101,11 @@ TEST(SSDDriverRead, ReadFailWithMockRunExe) {
 
 TEST_F(TestShellRead, ReadPassWithMockRunExe) {
 
-	EXPECT_CALL(SSDwithMockRunExe, runExe)
+	EXPECT_CALL(mockSSD, runExe)
 		.Times(1)
 		.WillRepeatedly(Return(true));
 
-	ReadCommand cmd{ &SSDwithMockRunExe };
+	ReadCommand cmd{ &mockSSD };
 
 	std::ostringstream oss;
 	auto oldCoutStreamBuf = std::cout.rdbuf();
@@ -127,11 +122,11 @@ TEST_F(TestShellRead, ReadPassWithMockRunExe) {
 TEST_F(TestShellRead, FullReadPassWithMockRunExe) {
 	ssdReadFileSetUp();
 
-	EXPECT_CALL(SSDwithMockRunExe, runExe)
+	EXPECT_CALL(mockSSD, runExe)
 		.Times(100)
 		.WillRepeatedly(Return(true));
 
-	FullReadCommand cmd{ &SSDwithMockRunExe };
+	FullReadCommand cmd{ &mockSSD };
 
 	std::ostringstream oss;
 	auto oldCoutStreamBuf = std::cout.rdbuf();
@@ -158,10 +153,10 @@ TEST_F(TestShellRead, FullReadPassWithMockRunExe) {
 
 TEST_F(TestShellRead, ReadFailWithMockRunExe) {
 
-	EXPECT_CALL(SSDwithMockRunExe, runExe)
+	EXPECT_CALL(mockSSD, runExe)
 		.WillRepeatedly(Return(false));
 
-	ReadCommand cmd{ &SSDwithMockRunExe };
+	ReadCommand cmd{ &mockSSD };
 
 	std::ostringstream oss;
 	auto oldCoutStreamBuf = std::cout.rdbuf();
@@ -177,10 +172,10 @@ TEST_F(TestShellRead, ReadFailWithMockRunExe) {
 TEST_F(TestShellRead, FullReadFailWithMockRunExe) {
 	ssdReadFileSetUp();
 
-	EXPECT_CALL(SSDwithMockRunExe, runExe)
+	EXPECT_CALL(mockSSD, runExe)
 		.WillRepeatedly(Return(false));
 
-	FullReadCommand cmd{ &SSDwithMockRunExe };
+	FullReadCommand cmd{ &mockSSD };
 
 	std::ostringstream oss;
 	auto oldCoutStreamBuf = std::cout.rdbuf();

--- a/TestShell/shell_write_test.cpp
+++ b/TestShell/shell_write_test.cpp
@@ -9,7 +9,7 @@ public:
 	const int VALID_LBA = 10;
 	const int OVER_LBA = 100;
 	const int UNDER_LBA = -1;
-	MockSSD mockSSD;
+	MockSSDDriver mockSSD;
 	SSDDriver realSSD;
 	MockSSDDriver mockSSDDriver;
 	WriteCommand writeCmd{ &mockSSD };

--- a/TestShell/test_scripts_test.cpp
+++ b/TestShell/test_scripts_test.cpp
@@ -15,7 +15,7 @@ public:
 		if (scriptName == "EraseAndWriteAging") script = new ScriptsEraseAndWriteAging(&mockSSD);
 
 	}
-	NiceMock<MockSSD> mockSSD;
+	NiceMock<MockSSDDriver> mockSSD;
 	string invalidData = "0xFFFFFFFF";
 	string testData = "0x00012345";
 	string erasedData = "0x00000000";

--- a/TestShell/testshell_execute_command_test.cpp
+++ b/TestShell/testshell_execute_command_test.cpp
@@ -14,7 +14,7 @@ public:
 		app.setSSD(&mockSSD);
 	}
 public:
-	MockSSD mockSSD;
+	MockSSDDriver mockSSD;
 	string testData = "0x00012345";
 };
 


### PR DESCRIPTION
## 📌 PR 제목
- [refactoring] Merge MockSSD & MockSSDDriver

## 📄 변경 사항
- SSDInterface를 상속하는 MockSSD 클래스와, SSDInterface를 상속하는 SSDDriver를 상속하는 MockSSD 클래스를 통합

## 🔍 상세 설명
- 결국은 MockSSDDRiver가 MockSSD + Mock_Method(RunEXE) = SSDDriver에 대한 Mcok 객체이기 때문

## ✅ 체크리스트
- [ ] 코드 스타일을 따랐는가?
- [x] 테스트를 작성했는가?
- [x] master branch 리베이스 후 빌드 확인 하였는가?