### PR TITLE
[refactoring] Change Name of Mock SSD Driver

### DIFF
--- a/TestShell/mock_ssd.h
+++ b/TestShell/mock_ssd.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "test_shell.h"
 
-class MockSSD : public SSDInterface {
+class MockSSDDriver : public SSDInterface {
 public:
 	MOCK_METHOD(void, write, (int lba, string value), (override));
 	MOCK_METHOD(string, read, (int lba), (override));
@@ -9,7 +9,7 @@ public:
 	MOCK_METHOD(void, flush, (), (override));
 };
 
-class MockSSDDriver : public SSDDriver {
+class MockSSDDriverForRunExe : public SSDDriver {
 public:
 	MOCK_METHOD(bool, runExe, (const string& command), (override));
 };

--- a/TestShell/shell_read_test.cpp
+++ b/TestShell/shell_read_test.cpp
@@ -6,8 +6,8 @@ using namespace testing;
 
 class TestShellRead : public Test, public HandleConsoleOutputFixture {
 public:
-	MockSSD mockSSD;
-	MockSSDDriver SSDwithMockRunExe;
+	MockSSDDriver mockSSD;
+	MockSSDDriverForRunExe SSDwithMockRunExe;
 	TestShell shell;
 
 	const string HEADER = "[Read] LBA ";
@@ -79,7 +79,7 @@ TEST_F(TestShellRead, FullReadPassWithMockSSD) {
 
 
 TEST(SSDDriverRead, ReadPassWithMockRunExe) {
-	MockSSDDriver SSDwithMockRunExe;
+	MockSSDDriverForRunExe SSDwithMockRunExe;
 
 	EXPECT_CALL(SSDwithMockRunExe, runExe)
 		.Times(1)
@@ -89,7 +89,7 @@ TEST(SSDDriverRead, ReadPassWithMockRunExe) {
 }
 
 TEST(SSDDriverRead, ReadFailWithMockRunExe) {
-	MockSSDDriver SSDwithMockRunExe;
+	MockSSDDriverForRunExe SSDwithMockRunExe;
 
 	EXPECT_CALL(SSDwithMockRunExe, runExe)
 		.Times(1)
@@ -100,7 +100,7 @@ TEST(SSDDriverRead, ReadFailWithMockRunExe) {
 		FAIL();
 	}
 	catch (std::runtime_error e) {
-		EXPECT_EQ(std::string(e.what()), "Failed to execute ssd.exe for read()");
+		EXPECT_EQ(std::string(e.what()), "Failed to execute ssd.exe for read()\n");
 	}
 }
 
@@ -171,7 +171,7 @@ TEST_F(TestShellRead, ReadFailWithMockRunExe) {
 	cmd.execute(args);
 	std::cout.rdbuf(oldCoutStreamBuf);
 
-	EXPECT_EQ("Executing read from LBA 0\nFailed to execute ssd.exe for read()", oss.str());
+	EXPECT_EQ("Executing read from LBA 0\nFailed to execute ssd.exe for read()\n", oss.str());
 }
 
 TEST_F(TestShellRead, FullReadFailWithMockRunExe) {
@@ -190,5 +190,5 @@ TEST_F(TestShellRead, FullReadFailWithMockRunExe) {
 	cmd.execute(args);
 	std::cout.rdbuf(oldCoutStreamBuf);
 
-	EXPECT_EQ("Executing fullread\nFailed to execute ssd.exe for read()", oss.str());
+	EXPECT_EQ("Executing fullread\nFailed to execute ssd.exe for read()\n", oss.str());
 }

--- a/TestShell/shell_read_test.cpp
+++ b/TestShell/shell_read_test.cpp
@@ -78,8 +78,7 @@ TEST_F(TestShellRead, FullReadPassWithMockSSD) {
 }
 
 
-TEST(SSDDriverRead, ReadPassWithMockRunExe) {
-	MockSSDDriverForRunExe SSDwithMockRunExe;
+TEST_F(TestShellRead, SSDReadPassWithMockRunExe) {
 
 	EXPECT_CALL(SSDwithMockRunExe, runExe)
 		.Times(1)
@@ -88,8 +87,7 @@ TEST(SSDDriverRead, ReadPassWithMockRunExe) {
 	EXPECT_EQ("0xAAAAAAAA", SSDwithMockRunExe.read(0));
 }
 
-TEST(SSDDriverRead, ReadFailWithMockRunExe) {
-	MockSSDDriverForRunExe SSDwithMockRunExe;
+TEST_F(TestShellRead, ShellReadFailWithMockRunExe) {
 
 	EXPECT_CALL(SSDwithMockRunExe, runExe)
 		.Times(1)
@@ -104,7 +102,7 @@ TEST(SSDDriverRead, ReadFailWithMockRunExe) {
 	}
 }
 
-TEST_F(TestShellRead, ReadPassWithMockRunExe) {
+TEST_F(TestShellRead, CMDReadPassWithMockRunExe) {
 
 	EXPECT_CALL(SSDwithMockRunExe, runExe)
 		.Times(1)
@@ -156,7 +154,7 @@ TEST_F(TestShellRead, FullReadPassWithMockRunExe) {
 	EXPECT_EQ(expect, excludeFirstLine(oss.str()));
 }
 
-TEST_F(TestShellRead, ReadFailWithMockRunExe) {
+TEST_F(TestShellRead, CMDReadFailWithMockRunExe) {
 
 	EXPECT_CALL(SSDwithMockRunExe, runExe)
 		.WillRepeatedly(Return(false));

--- a/TestShell/shell_write_test.cpp
+++ b/TestShell/shell_write_test.cpp
@@ -9,9 +9,9 @@ public:
 	const int VALID_LBA = 10;
 	const int OVER_LBA = 100;
 	const int UNDER_LBA = -1;
-	MockSSD mockSSD;
+	MockSSDDriver mockSSD;
 	SSDDriver realSSD;
-	MockSSDDriver mockSSDDriver;
+	MockSSDDriverForRunExe mockSSDDriver;
 	WriteCommand writeCmd{ &mockSSD };
 	FullWriteCommand fullWriteCmd{ &mockSSD };
 	std::string value = "0x12345678";

--- a/TestShell/test_scripts_test.cpp
+++ b/TestShell/test_scripts_test.cpp
@@ -15,7 +15,7 @@ public:
 		if (scriptName == "EraseAndWriteAging") script = new ScriptsEraseAndWriteAging(&mockSSD);
 
 	}
-	NiceMock<MockSSD> mockSSD;
+	NiceMock<MockSSDDriver> mockSSD;
 	string invalidData = "0xFFFFFFFF";
 	string testData = "0x00012345";
 	string erasedData = "0x00000000";

--- a/TestShell/testshell_execute_command_test.cpp
+++ b/TestShell/testshell_execute_command_test.cpp
@@ -14,7 +14,7 @@ public:
 		app.setSSD(&mockSSD);
 	}
 public:
-	MockSSD mockSSD;
+	MockSSDDriver mockSSD;
 	string testData = "0x00012345";
 };
 


### PR DESCRIPTION
## 📌 PR 제목
- [refactoring] Change Name of Mock SSD Driver

## 📄 변경 사항
- MockSSDDriver -> MockSSDDriverForRunExe
- MockSSD -> MockSSDDriver
- Unit Test Pass를 위한 expect 값에 \n 추가

## 🔍 상세 설명
- 원래는 MockSSD와 MockSSDDriver를 합치려고 했으나, 개발 시 만든 Unit Test 에서 Fail 발생해 두개를 구분해 개발했던 원인이 생각이 나서 다시 수정함 
- MockSSD는 SSDDriver 개발 전 Test Shell의 read, write, erase, flush 개발/검증용
- MockSSDDriver는 SSD.exe 개발 전 SSDDriver의 read, write, erase, flush 개발/검증용

## ✅ 체크리스트
- [ ] 코드 스타일을 따랐는가?
- [x] 테스트를 작성했는가?
- [x] master branch 리베이스 후 빌드 확인 하였는가?